### PR TITLE
Add Stream Configuration Support to API

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source=amplipi
+

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,3 +33,19 @@ jobs:
       run: |
         pytest tests/test_ctrl.py -vv
         pytest tests/test_rest.py -vv
+    - name: Generate coverage report
+      run: |
+        pip install pytest
+        pip install pytest-cov
+        pytest --cov=./ --cov-report=xml -vv
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./coverage.xml
+        directory: ./coverage/reports/
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: codecov-umbrella
+        fail_ci_if_error: true
+        path_to_write_report: ./coverage/codecov_report.txt
+        verbose: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,4 +31,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test mock using pytest # rpi cannot be tested directly due to hardware...
       run: |
-        pytest tests/test_rest.py -v
+        pytest tests/test_ctrl.py -vv
+        pytest tests/test_rest.py -vv

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,6 +29,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-#    - name: Test mock using pytest # rpi cannot be tested directly due to hardware...
-#      run: |
-#        pytest tests/test_ethaudio.py -v
+    - name: Test mock using pytest # rpi cannot be tested directly due to hardware...
+      run: |
+        pytest tests/test_rest.py -v

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,6 +46,5 @@ jobs:
         flags: unittests
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         path_to_write_report: ./coverage/codecov_report.txt
-        verbose: true

--- a/amplipi/__init__.py
+++ b/amplipi/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["ctrl", "rt", "streams"]

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -104,7 +104,7 @@ def get_source(src):
   if src >= 0 and src < len(sources):
     return sources[src]
   else:
-    return None, 404
+    return {}, 404
 
 @app.route('/api/sources/<int:src>', methods=['PATCH'])
 def set_source(src):
@@ -118,7 +118,7 @@ def get_zone(zone):
   if zone >= 0 and zone < len(zones):
     return zones[zone]
   else:
-    return None, 404
+    return {}, 404
 
 @app.route('/api/zones/<int:zone>', methods=['PATCH'])
 def set_zone(zone):
@@ -136,7 +136,7 @@ def get_group(group):
   if group >= 0 and group < len(groups):
     return groups[group]
   else:
-    return None, 404
+    return {}, 404
 
 @app.route('/api/groups/<int:group>', methods=['PATCH'])
 def set_group(group):
@@ -150,10 +150,11 @@ def delete_group(group):
 
 @app.route('/api/stream', methods=['POST'])
 def create_stream():
-  return None, 404 # TODO: implement create_stream
+  return {}, 404 # TODO: implement create_stream
 
 @app.route('/api/streams/<int:stream>', methods=['PATCH'])
 def set_stream(stream):
+  print(request.get_json())
   return code_response(app.api.set_stream(id=stream, **request.get_json()))
 
 # TODO: add specific route for /api/stream/<int:stream>/cmd that sends a command to a stream returns the stream's state on success or an error

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -25,6 +25,7 @@ Flask is used to simplify the web plumbing.
 from flask import Flask, request, render_template, jsonify, make_response
 import amplipi.ctrl as ctrl
 import amplipi.rt as rt
+import amplipi.utils as utils
 import json
 from collections import OrderedDict
 
@@ -74,9 +75,6 @@ def song_info(src):
     if field not in info:
       info[field] = ''
   return info
-
-def get_element(_list: list, id: int):
-  return next(filter(lambda element: element['id'] == id, _list), None)
 
 # API
 # TODO: add debug printing to each request, ie.
@@ -158,7 +156,7 @@ def create_stream():
 
 @app.route('/api/streams/<int:sid>', methods=['GET'])
 def get_stream(sid):
-  stream = get_element(app.api.get_state()['streams'], sid)
+  _, stream = utils.find(app.api.get_state()['streams'], sid)
   if stream is not None:
     return stream
   else:

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -166,6 +166,10 @@ def get_stream(sid):
 def set_stream(sid):
   return code_response(app.api.set_stream(id=sid, **request.get_json()))
 
+@app.route('/api/streams/<int:sid>', methods=['DELETE'])
+def delete_stream(sid):
+  return code_response(app.api.delete_stream(id=sid))
+
 # TODO: add specific route for /api/stream/<int:stream>/cmd that sends a command to a stream returns the stream's state on success or an error
 
 # documentation

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -75,6 +75,9 @@ def song_info(src):
       info[field] = ''
   return info
 
+def get_element(_list: list, id: int):
+  return next(filter(lambda element: element['id'] == id, _list), None)
+
 # API
 # TODO: add debug printing to each request, ie.
 #   if DEBUG_API:
@@ -150,12 +153,20 @@ def delete_group(group):
 
 @app.route('/api/stream', methods=['POST'])
 def create_stream():
-  return {}, 404 # TODO: implement create_stream
+  print('creating stream from {}'.format(request.get_json()))
+  return code_response(app.api.create_stream(**request.get_json()))
 
-@app.route('/api/streams/<int:stream>', methods=['PATCH'])
-def set_stream(stream):
-  print(request.get_json())
-  return code_response(app.api.set_stream(id=stream, **request.get_json()))
+@app.route('/api/streams/<int:sid>', methods=['GET'])
+def get_stream(sid):
+  stream = get_element(app.api.get_state()['streams'], sid)
+  if stream is not None:
+    return stream
+  else:
+    return {}, 404
+
+@app.route('/api/streams/<int:sid>', methods=['PATCH'])
+def set_stream(sid):
+  return code_response(app.api.set_stream(id=sid, **request.get_json()))
 
 # TODO: add specific route for /api/stream/<int:stream>/cmd that sends a command to a stream returns the stream's state on success or an error
 

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -68,7 +68,7 @@ def ungrouped_zones(src):
 def song_info(src):
   """ Get the song info for a source """
   song_fields = ['artist', 'album', 'track', 'img_url']
-  stream = app.api.get_stream(app.api.status['sources'][src]['input'])
+  stream = app.api._get_stream(app.api.status['sources'][src]['input'])
   info = stream.info() if stream else {}
   # add empty strings for unpopulated fields
   for field in song_fields:
@@ -172,7 +172,6 @@ def delete_stream(sid):
 
 @app.route('/api/streams/<int:sid>/<cmd>', methods=['POST'])
 def exec_command(sid, cmd):
-  print('creating stream from {}'.format(request.get_json()))
   return code_response(app.api.exec_stream_command(id=sid, cmd=cmd))
 
 # documentation

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -170,7 +170,7 @@ def set_stream(sid):
 def delete_stream(sid):
   return code_response(app.api.delete_stream(id=sid))
 
-@app.route('/api/streams/<int:sid>/<str:cmd>', methods=['POST'])
+@app.route('/api/streams/<int:sid>/<cmd>', methods=['POST'])
 def exec_command(sid, cmd):
   print('creating stream from {}'.format(request.get_json()))
   return code_response(app.api.exec_stream_command(id=sid, cmd=cmd))

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -170,7 +170,10 @@ def set_stream(sid):
 def delete_stream(sid):
   return code_response(app.api.delete_stream(id=sid))
 
-# TODO: add specific route for /api/stream/<int:stream>/cmd that sends a command to a stream returns the stream's state on success or an error
+@app.route('/api/streams/<int:sid>/<str:cmd>', methods=['POST'])
+def exec_command(sid, cmd):
+  print('creating stream from {}'.format(request.get_json()))
+  return code_response(app.api.exec_stream_command(id=sid, cmd=cmd))
 
 # documentation
 

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -64,7 +64,7 @@ class Api:
     ]
   }
 
-  def __init__(self, _rt=rt.Mock(), mock_streams=True, config_file='saved_state.json'):
+  def __init__(self, _rt=rt.Mock(), mock_streams=True, config_file='config/house.json'):
     self._rt = _rt
     self._mock_hw = type(_rt) is rt.Mock
     self._mock_streams = mock_streams

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -531,6 +531,17 @@ class Api:
       return utils.error('Unable to reconfigure stream {}: {}'.format(id, e))
 
   @utils.save_on_success
+  def delete_stream(self, id):
+    """Deletes an existing stream"""
+    try:
+      del self.streams[id]
+      i, _ = utils.find(self.status['streams'], id)
+      if i is not None:
+        del self.status['streams'][i] # delete the cached stream state just in case
+    except KeyError:
+      return utils.error('delete stream failed: {} does not exist'.format(id))
+
+  @utils.save_on_success
   def exec_stream_command(self, id, cmd):
     # TODO: this needs to be handled inside the stream itself, each stream can have a set of commands available
     if int(id) not in self.streams:

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -380,12 +380,6 @@ class Api:
     else:
         return utils.error('set zone: index {} out of bounds'.format(idx))
 
-  def get_group(self, id):
-    for i, g in enumerate(self.status['groups']):
-      if g['id'] == int(id):
-        return i,g
-    return None, None
-
   def _update_groups(self):
     """Updates the group's aggregate fields to maintain consistency and simplify app interface"""
     for g in self.status['groups']:
@@ -417,7 +411,7 @@ class Api:
         Returns:
             'None' on success, otherwise error (dict)
     """
-    _, g = self.get_group(id)
+    _, g = utils.find(self.status['groups'], id)
     if g is None:
       return utils.error('set group failed, group {} not found'.format(id))
     if type(zones) is str:
@@ -492,7 +486,7 @@ class Api:
   def delete_group(self, id):
     """Deletes an existing group"""
     try:
-      i, _ = self.get_group(id)
+      i, _ = utils.find(self.status['groups'], id)
       if i is not None:
         del self.status['groups'][i]
     except KeyError:

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -50,6 +50,9 @@ def updated_val(update, val):
   else:
     return update, update != val
 
+def find(_list, id):
+  return next(filter(lambda ie: ie[1]['id'] == id, enumerate(_list)), (None, None))
+
 def clamp(x, xmin, xmax):
     return max(xmin, min(x, xmax))
 

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -40,6 +40,7 @@ def parse_int(i, options):
 
 def error(msg):
   """ wrap the error message specified by msg into an error """
+  print('Error: {}'.format(msg))
   return {'error': msg}
 
 def updated_val(update, val):

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -50,8 +50,8 @@ def updated_val(update, val):
   else:
     return update, update != val
 
-def find(_list, id):
-  return next(filter(lambda ie: ie[1]['id'] == id, enumerate(_list)), (None, None))
+def find(items, id):
+  return next(filter(lambda ie: ie[1]['id'] == id, enumerate(items)), (None, None))
 
 def clamp(x, xmin, xmax):
     return max(xmin, min(x, xmax))

--- a/docs/amplipi_api.yaml
+++ b/docs/amplipi_api.yaml
@@ -221,6 +221,9 @@ paths:
             type: integer
             minimum: 0
             maximum: 3
+          examples:
+            Source 2:
+              value: 1
       responses:
         '200':
           description: Source Found
@@ -250,6 +253,9 @@ paths:
             type: integer
             minimum: 0
             maximum: 3
+          examples:
+            Source 4:
+              value: 3
       operationId: patch-source
       responses:
         '200':
@@ -291,6 +297,9 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Office:
+              value: 1
       responses:
         '200':
           description: Zone Found
@@ -322,6 +331,9 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Kitchen:
+              value: 5
       operationId: patch-zone
       responses:
         '200':

--- a/docs/amplipi_api.yaml
+++ b/docs/amplipi_api.yaml
@@ -527,6 +527,46 @@ paths:
                 $ref: '#/components/schemas/Status'
         '404':
           description: Group Not Found
+  /stream:
+    post:
+      summary: Create New stream
+      tags:
+        - stream
+      operationId: post-stream
+      responses:
+        '200':
+          description: Stream Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Stream'
+        '400':
+          description: Missing Required Information
+        '409':
+          description: Stream ID already taken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Friendly stream name, ie. Matt and Kim Radio
+                type:
+                  type: string
+                  description: Stream type
+                  enum:
+                    - pandora
+                    - shairport
+                info:
+                  type: object
+                  description: Additional info about the current audio playing from the stream
+                status:
+                  type: string
+                  description: connected/playing status of the stream
+        description: Post the necessary fields for the API to create a new stream.
+      description: Create a new stream.
   /streams/{streamId}:
     get:
       summary: Get Stream Info by Stream ID
@@ -541,7 +581,7 @@ paths:
             minimum: 0
       responses:
         '200':
-          description: Stream Found
+          description: Stream Command Success
           content:
             application/json:
               schema:
@@ -561,7 +601,120 @@ paths:
           description: Stream Not Found
       operationId: get-stream
       description: Retrieve the stream status and configuration information for the stream with the matching ID.
-
+    patch:
+      summary: Update Stream
+      tags:
+        - stream
+      parameters:
+        - name: streamId
+          required: true
+          in: path
+          schema:
+            type: integer
+            minimum: 0
+      operationId: patch-stream
+      responses:
+        '200':
+          description: Stream Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+        '404':
+          description: Stream Not Found
+      description: Update the configuration of a stream.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Update stream name
+                user:
+                  type: string
+                  description: Update stream account user name
+                password:
+                  type: string
+                  description: Update stream account password
+                station:
+                  type: integer
+                  minimum: 0
+                  description: Station id (number at the end of Pandora URL)
+            examples:
+              Change name:
+                value:
+                  name: Matt and Kim Radio
+              Change account info:
+                value:
+                  user: test@micro-nova.com
+                  password: sd9sk3k30
+              Change pandora radio station:
+                value:
+                  station: 0982034049300
+        description: Patch stream configuration to update.
+    delete:
+      summary: Delete Stream
+      tags:
+        - stream
+      parameters:
+        - name: streamId
+          required: true
+          in: path
+          schema:
+            type: integer
+            minimum: 0
+      operationId: delete-stream
+      description: Delete a stream
+      responses:
+        '200':
+          description: Stream Deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+        '404':
+          description: Stream Not Found
+  /streams/{streamId}/{streamCmd}:
+    post:
+      summary: Send a command to a connected stream such as Play/Pause/Next
+      tags:
+        - stream
+      parameters:
+        - name: streamId
+          required: true
+          in: path
+          schema:
+            type: integer
+            minimum: 0
+        - name: streamCmd
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Return status after command executed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Stream'
+              examples:
+                Play paused station:
+                  value:
+                    id: 90991
+                    name: Matt and Kim Radio
+                    status: playing
+                    info:
+                      artist: Matt and Kim
+                      song: Daylight
+                      album: Sidewalks
+        # TODO: add command not found, and stream not connected error results
+        '404':
+          description: Stream Not Found
+      operationId: post-stream-command
+      description: Send a command to the connected stream with the matching ID.
 components:
   schemas:
     Source:
@@ -595,6 +748,11 @@ components:
       type: object
       description: Digital stream such as Pandora, Airplay or Spotify
       properties:
+        id:
+          type: integer
+          format: int32
+          minimum: 0
+          description: Unique stream identifier
         name:
           type: string
           description: Friendly stream name, ie. Matt and Kim Radio
@@ -611,6 +769,7 @@ components:
           type: string
           description: connected/playing status of the stream
       required:
+        - id
         - name
         - type
     Zone:

--- a/docs/amplipi_api.yaml
+++ b/docs/amplipi_api.yaml
@@ -20,10 +20,6 @@ info:
 servers:
   - url: 'http://amplipi.local:5000/api'
     description: Local AmpliPi Controller
-  - url: 'http://raspberrypi.local:5000/api'
-    description: Demo AmpliPi Controller
-  - url: 'http://linkxps.local:5000/api'
-    description: Dev AmpliPi Controller
 tags:
 - name: status
   description: The status and configuration of the entire system, including source, zones, groups, and streams.
@@ -418,6 +414,9 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Whole House:
+              value: 1
       responses:
         '200':
           description: Group Found
@@ -448,6 +447,9 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Downstairs:
+              value: 2
       operationId: patch-group
       responses:
         '200':
@@ -516,6 +518,9 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Upstairs:
+              value: 3
       operationId: delete-group
       description: Delete a group
       responses:
@@ -540,6 +545,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Stream'
+              example:
+                name: Matt and Kim Radio
+                type: pandora
+                user: test@micro-nova.com
+                password: s79sDDkjf
+                info: {}
+                status: disconnected
         '400':
           description: Missing Required Information
         '409':
@@ -559,12 +571,20 @@ paths:
                   enum:
                     - pandora
                     - shairport
-                info:
-                  type: object
-                  description: Additional info about the current audio playing from the stream
-                status:
+                    - spotify
+                user:
                   type: string
-                  description: connected/playing status of the stream
+                  description: Stream account user name (for pandora this is an email address)
+                password:
+                  type: string
+                  description: Stream account password
+            examples:
+              Add Matt and Kim Radio:
+                value:
+                  name: Matt and Kim Radio
+                  type: pandora
+                  user: test@micro-nova.com
+                  password: s79sDDkjf
         description: Post the necessary fields for the API to create a new stream.
       description: Create a new stream.
   /streams/{streamId}:
@@ -579,6 +599,9 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Matt and Kim Radio:
+              value: 90891
       responses:
         '200':
           description: Stream Command Success
@@ -589,7 +612,7 @@ paths:
               examples:
                 Get Matt and Kim Radio Stream:
                   value:
-                    id: 90991
+                    id: 90891
                     name: Matt and Kim Radio
                     status: playing
                     info:
@@ -612,6 +635,9 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Matt and Kim Radio:
+              value: 90891
       operationId: patch-stream
       responses:
         '200':
@@ -642,6 +668,8 @@ paths:
                   type: integer
                   minimum: 0
                   description: Station id (number at the end of Pandora URL)
+              required:
+                - name
             examples:
               Change name:
                 value:
@@ -665,6 +693,9 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Matt and Kim Radio:
+              value: 90891
       operationId: delete-stream
       description: Delete a stream
       responses:
@@ -688,11 +719,50 @@ paths:
           schema:
             type: integer
             minimum: 0
+          examples:
+            Matt and Kim Radio:
+              value: 90891
         - name: streamCmd
           required: true
           in: path
           schema:
             type: string
+          examples:
+            Play Stream:
+              value: play
+            Pause Stream:
+              value: pause
+            Skip to next song:
+              value: next
+            Stop Stream:
+              value: stop
+            Like/Love Current Song:
+              value: like
+            Ban Current Song (pandora only):
+              value: ban
+            Shelve Current Song (pandora only):
+              value: shelve
+            Change Station (pandora only):
+              value: station
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                station:
+                  type: integer
+                  description: Pandora station id
+            examples:
+              Change station (pandora only):
+                value:
+                  station: 0982034049300
+              Play Stream:
+                value: {}
+              Pause Stream:
+                value: {}
+              Skip to next song:
+                value: {}
       responses:
         '200':
           description: Return status after command executed
@@ -703,7 +773,7 @@ paths:
               examples:
                 Play paused station:
                   value:
-                    id: 90991
+                    id: 90891
                     name: Matt and Kim Radio
                     status: playing
                     info:

--- a/docs/amplipi_api.yaml
+++ b/docs/amplipi_api.yaml
@@ -755,26 +755,7 @@ paths:
             Shelve Current Song (pandora only):
               value: shelve
             Change Station (pandora only):
-              value: station
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                station:
-                  type: integer
-                  description: Pandora station id
-            examples:
-              Change station (pandora only):
-                value:
-                  station: 0982034049300
-              Play Stream:
-                value: {}
-              Pause Stream:
-                value: {}
-              Skip to next song:
-                value: {}
+              value: station=0982034049300
       responses:
         '200':
           description: Return status after command executed

--- a/tests/context.py
+++ b/tests/context.py
@@ -3,3 +3,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import amplipi
+import amplipi.ctrl
+import amplipi.rt
+import amplipi.streams
+import amplipi.app

--- a/tests/test_ctrl.py
+++ b/tests/test_ctrl.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
-# this file is expected to be run using pytest, ie. pytest python/tests/test_ethaudio_mock.py
+# this file is expected to be run using pytest, ie. pytest tests/test_ethaudio_mock.py
 
 import argparse
 from copy import deepcopy
 import deepdiff
 
-# use the internal ethaudio library
-import amplipi
+# use the internal amplipi library
+from context import amplipi
 
 # modify json config files
 import json
@@ -14,7 +14,7 @@ import os
 import tempfile
 
 # several starting configurations to load for testing including a corrupted configuration
-DEFAULT_STATUS = deepcopy(amplipi.api.EthAudioApi.DEFAULT_CONFIG)
+DEFAULT_STATUS = deepcopy(amplipi.ctrl.Api._DEFAULT_CONFIG)
 # make a good config string, that has less groups than the default (so we can tell the difference)
 GOOD_STATUS = deepcopy(DEFAULT_STATUS)
 del GOOD_STATUS['groups'][2]
@@ -413,7 +413,7 @@ def api_w_mock_rt(config=None, backup_config=None):
   #   (a None config file means that config file will be deleted before launch)
   setup_test_configs(config, backup_config)
   # start the api (we have a specfic config path we use for all tests)
-  return amplipi.api.EthAudioApi(amplipi.api.MockRt(), config_file=CONFIG_FILE)
+  return amplipi.ctrl.Api(amplipi.rt.Mock(), config_file=CONFIG_FILE)
 
 def api_w_rpi_rt(config=None, backup_config=None):
   # copy in specfic config files (paths) to know config locations
@@ -421,7 +421,7 @@ def api_w_rpi_rt(config=None, backup_config=None):
   #   (a None config file means that config file will be deleted before launch)
   setup_test_configs(config, backup_config)
   # start the api (we have a specfic config path we use for all tests)
-  return amplipi.api.EthAudioApi(amplipi.api.RpiRt(mock=True), config_file=CONFIG_FILE)
+  return amplipi.ctrl.Api(amplipi.rt.Rpi(mock=True), config_file=CONFIG_FILE)
 
 def use_tmpdir():
   # lets run these tests in a temporary directory so they dont mess with other tests config files

--- a/tests/test_ctrl.py
+++ b/tests/test_ctrl.py
@@ -35,11 +35,11 @@ test_sequence = [
     "command" : "set_source",
     "id" : 1,
     "name" : "cd player",
-    "type": "local"
+    "input": "local"
   },
   None,
   {
-    "sources[1].type" : "local",
+    "sources[1].input" : "local",
     "sources[1].name" : "cd player"
   }
 ),
@@ -192,11 +192,11 @@ test_sequence = [
     "command" : "set_source",
     "id" : 1,
     "name" : "Pandora",
-    "type": "pandora"
+    "input": "pandora"
   },
   None,
   {
-    "sources[1].type" : "pandora",
+    "sources[1].input" : "stream=1001",
     "sources[1].name" : "Pandora"
   }
 ),
@@ -355,8 +355,8 @@ def check_all_tsts(api):
   print(eth_audio_api.get_state())
   print('\ntesting commands:')
   # Tests
-  check_json_tst('Configure source 0 (shairport)', eth_audio_api.set_source(0, 'Shairport', 'shairport'), None, {'sources[0].name' : 'Shairport', 'sources[0].type' : 'shairport'})
-  check_json_tst('Configure source 1 (pandora)', eth_audio_api.set_source(1, 'Pandora', 'pandora'), None, {'sources[1].name' : 'Pandora', 'sources[1].type' : 'pandora'})
+  check_json_tst('Configure source 0 (shairport)', eth_audio_api.set_source(0, 'Shairport', 'stream=1000'), None, {'sources[0].name' : 'Shairport', 'sources[0].input' : 'stream=1000'})
+  check_json_tst('Configure source 1 (pandora)', eth_audio_api.set_source(1, 'Pandora', 'stream=1001'), None, {'sources[1].name' : 'Pandora', 'sources[1].input' : 'stream=1001'})
   check_json_tst('Configure source 2 (local)', eth_audio_api.set_source(2, 'TV', 'local'), None, {'sources[2].name' : 'TV'})
   check_json_tst('Configure source 3 (local)', eth_audio_api.set_source(3, 'PC', 'local'), None, {'sources[3].name' : 'PC'})
   check_json_tst('Configure zone 0, Party Zone', eth_audio_api.set_zone(0, 'Party Zone', 1, False, 0, False), None, {'zones[0].name' : 'Party Zone', 'zones[0].source_id' : 1, 'zones[0].vol': 0, 'zones[0].mute' : False})
@@ -365,14 +365,6 @@ def check_all_tsts(api):
   check_json_tst('Configure zone 2, Sleep Zone', eth_audio_api.set_zone(2, 'Sleep Zone', 3, True, None, False), None, {'zones[2].name' : 'Sleep Zone', 'zones[2].source_id' : 3})
   check_json_tst('Configure zone 3, Standby Zone', eth_audio_api.set_zone(3, 'Standby Zone', 3, True, None, False), None, {'zones[3].name' : 'Standby Zone', 'zones[3].source_id' : 3})
   check_json_tst('Configure zone 4, Weird Zone', eth_audio_api.set_zone(4, 'Weird Zone', 1, None, None, None), None, {'zones[4].name' : 'Weird Zone', 'zones[4].source_id' : 1})
-
-  # Test string/json based command handler
-  print('\ntesting json:')
-  for name, cmd, expected_result, expected_changes  in test_sequence:
-    is_group_cmd = '_group' in cmd['command']
-    check_json_tst(name, eth_audio_api.parse_cmd(cmd), expected_result, expected_changes, ignore_group_changes=not is_group_cmd)
-
-# TODO: add openapi tests
 
 def delete_file(file_path):
   try:

--- a/tests/test_ctrl.py
+++ b/tests/test_ctrl.py
@@ -437,26 +437,33 @@ def test_rpi():
   use_tmpdir() # run from temp dir so we don't mess with current directory
   check_all_tsts(api_w_rpi_rt())
 
+def prune_state(state: dict):
+  """ Prune generated fields from system state to make comparable """
+  for s in state['streams']:
+    s.pop('info')
+    s.pop('status')
+  return state
+
 def test_config_loading():
   use_tmpdir() # run from temp dir so we don't mess with current directory
   # test loading an empty config (should load default config)
   api = api_w_mock_rt(NO_CONFIG, backup_config=NO_CONFIG)
-  assert DEFAULT_STATUS == api.get_state()
+  assert DEFAULT_STATUS == prune_state(api.get_state())
   # test loading a known good config file by making a copy of it and loading the api with the copy
   api = api_w_mock_rt(GOOD_CONFIG)
-  assert GOOD_STATUS == api.get_state()
+  assert GOOD_STATUS == prune_state(api.get_state())
   # test loading a corrupted config file with a good backup
   api = api_w_mock_rt(CORRUPTED_CONFIG, backup_config=GOOD_CONFIG)
-  assert GOOD_STATUS == api.get_state()
+  assert GOOD_STATUS == prune_state(api.get_state())
   # test loading a missing config file with a good backup
   api = api_w_mock_rt(NO_CONFIG, backup_config=GOOD_CONFIG)
-  assert GOOD_STATUS == api.get_state()
+  assert GOOD_STATUS == prune_state(api.get_state())
   # test loading a corrupted config file and a corrupted backup
   api = api_w_mock_rt(CORRUPTED_CONFIG, backup_config=CORRUPTED_CONFIG)
-  assert DEFAULT_STATUS == api.get_state()
+  assert DEFAULT_STATUS == prune_state(api.get_state())
   # test loading a missing config file and a missing backup
   api = api_w_mock_rt(NO_CONFIG, backup_config=NO_CONFIG)
-  assert DEFAULT_STATUS == api.get_state()
+  assert DEFAULT_STATUS == prune_state(api.get_state())
 
 
 if __name__ == '__main__':

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,0 +1,43 @@
+import pytest
+
+# json utils
+import json
+
+# temporary directory for each test config
+import tempfile
+import os
+
+# copy test config
+from copy import deepcopy
+
+# testing context
+from context import amplipi
+
+def base_config():
+  return deepcopy(amplipi.ctrl.Api._DEFAULT_CONFIG)
+
+def base_config_copy():
+  return deepcopy(base_config())
+
+@pytest.fixture
+def client(cfg=base_config_copy()):
+  config_dir = tempfile.mkdtemp()
+  config_file = os.path.join(config_dir, 'house.json')
+  with open(config_file, 'w') as cfg_file:
+    cfg_file.write(json.dumps(cfg))
+  app = amplipi.app.create_app(mock=True, config_file=config_file)
+  app.testing = True
+  return app.test_client()
+
+def test_base(client):
+    """Start with a basic controller and just check if it gives a real response"""
+    rv = client.get('/api/')
+    jrv = rv.get_json()
+    assert jrv != None
+    for t in ['sources', 'streams', 'zones', 'groups']:
+      assert len(jrv[t]) == len(base_config()[t])
+
+# TODO: test sources
+# TODO: test zones
+# TODO: test groups
+# TODO: test streams

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -73,7 +73,7 @@ def base_stream_ids():
 
 # /stream post-stream
 def test_create_pandora(client):
-  m_and_k = { 'name': 'Matt and Kim Radio', 'user': 'lincoln@micro-nova.com', 'password': ''}
+  m_and_k = { 'name': 'Matt and Kim Radio', 'type':'pandora', 'user': 'lincoln@micro-nova.com', 'password': ''}
   rv = client.post('/api/stream', json=m_and_k)
   # check that the stream has an id added to it and that all of the fields are still there
   assert rv.status_code == HTTPStatus.OK

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -2,6 +2,7 @@ import pytest
 
 # json utils
 import json
+from http import HTTPStatus
 
 # temporary directory for each test config
 import tempfile
@@ -19,14 +20,24 @@ def base_config():
 def base_config_copy():
   return deepcopy(base_config())
 
+def find(list, id):
+  for i in list:
+    if i['id'] == id:
+      return i
+  return None
+
 @pytest.fixture
-def client(cfg=base_config_copy()):
+def app(cfg=base_config_copy()):
   config_dir = tempfile.mkdtemp()
   config_file = os.path.join(config_dir, 'house.json')
   with open(config_file, 'w') as cfg_file:
     cfg_file.write(json.dumps(cfg))
-  app = amplipi.app.create_app(mock=True, config_file=config_file)
+  app = amplipi.app.create_app(mock_ctrl=True, mock_streams=True, config_file=config_file)
   app.testing = True
+  return app
+
+@pytest.fixture
+def client(app):
   return app.test_client()
 
 def test_base(client):
@@ -37,16 +48,35 @@ def test_base(client):
     for t in ['sources', 'streams', 'zones', 'groups']:
       assert len(jrv[t]) == len(base_config()[t])
 
-# TODO: test sources
-# TODO: test zones
-# TODO: test groups
 
-# TODO: test streams
+# To reduce the amount of boilerplate we use test parameters.
+# Examples: https://docs.pytest.org/en/stable/example/parametrize.html#paramexamples
+
+# TODO: test sources
+# TODO: /sources/{sourceId} get-source
+# TODO: /sources/{sourceId} patch-source
+
+# TODO: test zones
+# TODO: /zones/{zoneId} get-zone
+# TODO: /zones/{zoneId} patch-zone
+
+# TODO: test groups
+# TODO: /group post-group
+# TODO: /groups/{groupId} get-group
+# TODO: /groups/{groupId} patch-group
+# TODO: /groups/{groupId} delete-group
+
+# test streams
+def base_stream_ids():
+  """ Return all of the stream IDs belonging to each of the streams in the base config """
+  return [ s['id'] for s in base_config()['streams']]
+
 # /stream post-stream
 def test_create_pandora(client):
   m_and_k = { 'name': 'Matt and Kim Radio', 'user': 'lincoln@micro-nova.com', 'password': ''}
-  rv = client.post('/stream', json=m_and_k)
+  rv = client.post('/api/stream', json=m_and_k)
   # check that the stream has an id added to it and that all of the fields are still there
+  assert rv.status_code == HTTPStatus.OK
   jrv = rv.get_json()
   assert 'id' in jrv
   assert type(jrv['id']) == int
@@ -54,6 +84,42 @@ def test_create_pandora(client):
     assert jrv[k] == v
 
 # /streams/{streamId} get-stream
+@pytest.mark.parametrize('sid', base_stream_ids())
+def test_get_stream(client, sid):
+  rv = client.get('/api/streams/{}'.format(sid))
+  assert rv.status_code == HTTPStatus.OK
+  jrv = rv.get_json()
+  s = find(base_config()['streams'], sid)
+  assert s != None
+  assert s['name'] == jrv['name']
+
 # /streams/{streamId} patch-stream
+@pytest.mark.parametrize('sid', base_stream_ids())
+def test_patch_stream_rename(client, sid):
+  rv = client.patch('/api/streams/{}'.format(sid), json={'name': 'patched-name'})
+  assert rv.status_code == HTTPStatus.OK
+  jrv = rv.get_json() # get the system state returned
+  # TODO: check that the system state is valid
+  # make sure the stream was renamed
+  s = find(jrv['streams'], sid)
+  assert s != None
+  assert s['name'] == 'patched-name'
+
 # /streams/{streamId} delete-stream
-# /streams/{streamId}/{streamCmd} post-stream-command
+@pytest.mark.parametrize('sid', base_stream_ids())
+def test_delete_stream(client, sid):
+  rv = client.delete('/api/streams/{}'.format(sid))
+  assert rv.status_code == HTTPStatus.OK
+  jrv = rv.get_json() # get the system state returned
+  # TODO: check that the system state is valid
+  # make sure the stream was deleted
+  s = find(jrv['streams'], sid)
+  assert s == None
+  # make sure the rest of the streams are still there
+  for other_sid in base_stream_ids():
+    if other_sid != sid:
+      assert find(jrv['streams'], other_sid) != None
+
+# TODO: /streams/{streamId}/{streamCmd} post-stream-command
+# TODO: mocked streams do not currently handle state changes from commands
+#       these tests will require either a real system with passwords and account info or a better mock

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -40,4 +40,20 @@ def test_base(client):
 # TODO: test sources
 # TODO: test zones
 # TODO: test groups
+
 # TODO: test streams
+# /stream post-stream
+def test_create_pandora(client):
+  m_and_k = { 'name': 'Matt and Kim Radio', 'user': 'lincoln@micro-nova.com', 'password': ''}
+  rv = client.post('/stream', json=m_and_k)
+  # check that the stream has an id added to it and that all of the fields are still there
+  jrv = rv.get_json()
+  assert 'id' in jrv
+  assert type(jrv['id']) == int
+  for k, v in m_and_k.items():
+    assert jrv[k] == v
+
+# /streams/{streamId} get-stream
+# /streams/{streamId} patch-stream
+# /streams/{streamId} delete-stream
+# /streams/{streamId}/{streamCmd} post-stream-command

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -98,8 +98,7 @@ function sendStreamCommand(ctrl, command) {
   let src_input = player.dataset.srcInput;
   if (src_input.startsWith("stream=")) {
     let stream_id = Number(src_input.replace("stream=", ""));
-    let req = { "cmd" : command };
-    sendRequest('/streams/' + stream_id, 'PATCH', req);
+    sendRequest('/streams/' + stream_id + '/' + command, 'POST`', {});
   }
 }
 

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -98,7 +98,7 @@ function sendStreamCommand(ctrl, command) {
   let src_input = player.dataset.srcInput;
   if (src_input.startsWith("stream=")) {
     let stream_id = Number(src_input.replace("stream=", ""));
-    sendRequest('/streams/' + stream_id + '/' + command, 'POST`', {});
+    sendRequest('/streams/' + stream_id + '/' + command, 'POST', {});
   }
 }
 


### PR DESCRIPTION
Adds the following stream endpoints/commands to the API
* /stream post-stream
* /streams/{streamId} patch-stream
* /streams/{streamId} delete-stream
* /streams/{streamId}/{streamCmd} post-stream-command
Previously the stream configuration was mostly read-only from the API perspective and commands were part of the configuration. 

Once this is completed a web interface for stream configuration will need to be created.