### PR TITLE
Updates to all scripts involved in Shairport Metadata

### DIFF
--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -162,6 +162,9 @@ class Shairport:
             d['artist'] = data[0]
             d['track'] = data[1]
             d['album'] = data[2]
+            d['paused'] = data[3]
+            if int(data[4]):
+              d['img_url'] = '/static/imgs/srcs/{}/{}'.format(self.src, data[5]) 
         # return d
     except Exception as e:
       pass

--- a/config/shairport_metadata.bash
+++ b/config/shairport_metadata.bash
@@ -1,3 +1,8 @@
 #!/bin/bash
+# Clear out any previous album cover images, then navigate to the proper directory #
+rm -r -f /home/pi/web/static/imgs/srcs/$1/
+mkdir -p /home/pi/web/static/imgs/srcs/$1/
+cd /home/pi/web/static/imgs/srcs/$1/
+
 # Start the metadata service with argument $1 being the source number #
 cat /home/pi/config/srcs/$1/shairport-sync-metadata | shairport-sync-metadata-reader | /home/pi/scripts/sp_meta.py $1

--- a/config/shairport_metadata.bash
+++ b/config/shairport_metadata.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 # Clear out any previous album cover images, then navigate to the proper directory #
+src="$1"
+if ((src < 0 || src >= 4));
+then
+    exit 1;
+fi
 rm -r -f /home/pi/web/static/imgs/srcs/$1/
 mkdir -p /home/pi/web/static/imgs/srcs/$1/
 cd /home/pi/web/static/imgs/srcs/$1/

--- a/scripts/sp_meta.py
+++ b/scripts/sp_meta.py
@@ -18,7 +18,7 @@ p_status = ''
 def read_field():
     line = sys.stdin.readline()
     line = line.strip(' \n')
-    if line[-6:] == 'bytes.':
+    if line[-6:] == 'bytes.': # Works with Mike Brady version of shairport-sync-metadata-reader
         line = '"Picture: ' + line + '".'
     if line:
         while line[-2:] != '".':

--- a/scripts/sp_meta.py
+++ b/scripts/sp_meta.py
@@ -89,5 +89,15 @@ while True:
         f = open(cs_loc, 'w')
         f.write(data)
         f.close()
+    elif field == 'Image length':
+        lin = ',,,' + data
+        f = open(cs_loc, 'a')
+        f.write(lin)
+        f.close()
+    elif field == 'Image name':
+        pic = ',,,' + data
+        f = open(cs_loc, 'a')
+        f.write(pic)
+        f.close()
     elif field == '"End of file"':
         break

--- a/scripts/sp_meta.py
+++ b/scripts/sp_meta.py
@@ -89,7 +89,7 @@ while True:
         f = open(cs_loc, 'w')
         f.write(data)
         f.close()
-    elif field == 'Image length':
+    elif field == 'Image length': # 'Image length' and 'Image name' are new outputs from the MicroNova fork of shairport-sync-metadata-reader: https://github.com/micronova-jb/shairport-sync-metadata-reader
         lin = ',,,' + data
         f = open(cs_loc, 'a')
         f.write(lin)

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -165,16 +165,16 @@ function updateSourceView(status) {
           play_pause.classList.toggle('fa-play', !playing);
           play_pause.classList.toggle('fa-pause', playing);
           try {
-            // update album art
+            // update album art and track info
             cover.src = stream.info.img_url ? stream.info.img_url : icons['pandora'];
             artist.innerHTML = stream.info.artist ? stream.info.artist : artist.innerHTML;
             album.innerHTML = stream.info.album ? stream.info.album : album.innerHTML;
             song.innerHTML = stream.info.track ? stream.info.track : song.innerHTML;
           } catch (err) {}
         } else if (stream.type == 'shairport') {
-          // TODO: populate shairport album info
-          cover.src = icons['shairport'];
           try {
+            // update album art and track info
+            cover.src = stream.info.img_url ? stream.info.img_url : icons['shairport'];
             artist.innerHTML = stream.info.artist ? stream.info.artist : artist.innerHTML;
             album.innerHTML = stream.info.album ? stream.info.album : album.innerHTML;
             song.innerHTML = stream.info.track ? stream.info.track : song.innerHTML;


### PR DESCRIPTION
-streams.py: Pulls new data points out of currentSong, checks whether the picture is empty or not, then forwards the picture directory/name
-shairport_metadata.bash: cleans out photo repositories from previous instances, runs the metadata reader from the image directory so picture data is properly saved in the right place
sp_meta.py: Checks for the name and size of the image - this info gets saved in currentSong
script.js: Now makes use of the shairport cover art