### PR TITLE
Fix internetradio metadata

### DIFF
--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -622,7 +622,7 @@ class InternetRadio:
         d['artist'] = data['artist']
         d['song'] = data['song']
         d['img_url'] = self.logo
-        d['album'] = ""
+        d['station'] = data['station']
 
         return(d)
     except Exception:

--- a/docs/amplipi_api.yaml
+++ b/docs/amplipi_api.yaml
@@ -558,6 +558,18 @@ paths:
                   type: internetradio
                   url: http://ice2.somafm.com/groovesalad-16-aac
                   logo: https://somafm.com/img3/groovesalad-200.jpg
+              Add Beatles Internet Radio Station:
+                value:
+                  name: Beatles Radio
+                  type: internetradio
+                  url: http://www.beatlesradio.com:8000/stream/1/
+                  logo: http://www.beatlesradio.com/content/images/thumbs/0000587.gif
+              Add Classical KING Internet Radio Station:
+                value:
+                  name: Classical KING FM 98.1
+                  type: internetradio
+                  url: http://classicalking.streamguys1.com/king-fm-aac-iheart
+                  logo: https://i.iheart.com/v3/re/assets/images/7bcfd87a-de3e-47d0-b896-be0ed38c9d74.png
         description: Post the necessary fields for the API to create a new stream.
       description: Create a new stream.
   /streams/{streamId}:

--- a/scripts/run_debug_webserver
+++ b/scripts/run_debug_webserver
@@ -31,6 +31,7 @@ if [[ "$mock_streams" != "True" ]] ; then
   killall librespot > /dev/null
   killall pianobar > /dev/null
   killall shairport-sync > /dev/null
+  kill -KILL $(ps ax | grep 'python' | grep 'runvlc' | awk '{print $1}') > /dev/null
 fi
 
 # get directory that the script exists in

--- a/streams/runvlc.py
+++ b/streams/runvlc.py
@@ -67,21 +67,42 @@ if args.song_info:
 time.sleep(2)
 current_track = ''
 current_url = ''
+this_artist = ''
+this_title = ''
 
 # Monitor track meta data and update currently_playing file if the track changed
 while True:
   try:
     if str(player.get_state()) == 'State.Playing':
-      cur = str(media.get_meta(vlc.Meta.Artist)) + ' - ' + str(media.get_meta(vlc.Meta.Title))
+      nowplaying = str(media.get_meta(vlc.Meta.NowPlaying))
+
+      # 'nowplaying' metadata is used by some internet radio stations instead of separate artist and title
+      if nowplaying and nowplaying != 'None':
+        cur = nowplaying
+        # 'nowplaying' metadata is "almost" always: title - artist
+        split = nowplaying.split(' - ', 1)
+        
+        if (len(split) > 1):
+            this_artist = split[0]
+            this_title = split[1]
+        else:
+            this_artist = ''
+            this_title = cur
+      else:
+        # If 'nowplaying' metadata isn't being used, use separate 'artist' and 'title' metadata
+        cur = str(media.get_meta(vlc.Meta.Artist)) + ' - ' + str(media.get_meta(vlc.Meta.Title))
+        this_artist = str(media.get_meta(vlc.Meta.Artist))
+        this_title = str(media.get_meta(vlc.Meta.Title))
+
       if current_track != cur or current_url != vlc.bytes_to_str(media.get_mrl()):
         # Update currently_playing file if the track has changed
         current_track = cur
         current_url = vlc.bytes_to_str(media.get_mrl())
-        print('Current track: %s - %s' % (media.get_meta(vlc.Meta.Artist), media.get_meta(vlc.Meta.Title)))
+        print('Current track: %s' % (cur))
 
         song_info_json = json.dumps({
-          "artist": media.get_meta(vlc.Meta.Artist),
-          "song": media.get_meta(vlc.Meta.Title),
+          "artist": this_artist,
+          "song": this_title,
           "state": str(player.get_state())
         })
 

--- a/streams/runvlc.py
+++ b/streams/runvlc.py
@@ -69,6 +69,7 @@ current_track = ''
 current_url = ''
 this_artist = ''
 this_title = ''
+this_stationname = ''
 
 # Monitor track meta data and update currently_playing file if the track changed
 while True:
@@ -82,6 +83,9 @@ while True:
         # 'nowplaying' metadata is "almost" always: title - artist
         split = nowplaying.split(' - ', 1)
         
+        # Pass along the station name if it exists in Title metadata
+        this_stationname = str(media.get_meta(vlc.Meta.Title))
+        
         if (len(split) > 1):
             this_artist = split[0]
             this_title = split[1]
@@ -89,7 +93,6 @@ while True:
             this_artist = ''
             this_title = cur
       else:
-        # If 'nowplaying' metadata isn't being used, use separate 'artist' and 'title' metadata
         cur = str(media.get_meta(vlc.Meta.Artist)) + ' - ' + str(media.get_meta(vlc.Meta.Title))
         this_artist = str(media.get_meta(vlc.Meta.Artist))
         this_title = str(media.get_meta(vlc.Meta.Title))
@@ -103,6 +106,7 @@ while True:
         song_info_json = json.dumps({
           "artist": this_artist,
           "song": this_title,
+          "album": this_stationname,
           "state": str(player.get_state())
         })
 

--- a/streams/runvlc.py
+++ b/streams/runvlc.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # Use libvlc to play internetradio stations to a specific alsa output
@@ -35,6 +35,7 @@ parser.add_argument('url', type=str, help='internet radio station url')
 parser.add_argument('output', type=str, help='alsa output', nargs='?', default=None)
 parser.add_argument('--song-info', type=str, help='file to update with current song information in json format')
 parser.add_argument('--test', action='store_true', help='verify the url is valid and return')
+parser.add_argument('--verbose', action='store_true', help='show more verbose output')
 args = parser.parse_args()
 
 config = "--aout=alsa "
@@ -87,6 +88,15 @@ while True:
         'station': '',
         'state': 'playing',
       }
+
+      if args.verbose:
+        print(f"""vlc metadata:
+          Title: {media.get_meta(vlc.Meta.Title)}
+          NowPlaying: {media.get_meta(vlc.Meta.NowPlaying)}
+          Artist: {media.get_meta(vlc.Meta.Artist)}
+          Album: {media.get_meta(vlc.Meta.Album)}
+          Description: {media.get_meta(vlc.Meta.Description)}
+        """)
 
       # Pass along the station name if it exists in Title metadata
       latest_info['station'] = media.get_meta(vlc.Meta.Title)


### PR DESCRIPTION
Some stations use 'nowplaying' metadata instead of the separate 'artist' and 'title' metadata. This adds a check for the 'nowplaying' metadata and splits it into 'artist' and 'title' for AmpliPi.