### PR TITLE
Bootstrapping script upgrades

### DIFF
--- a/scripts/bootstrap_pi
+++ b/scripts/bootstrap_pi
@@ -6,10 +6,11 @@ helptext="Usage: bootstrap_pi diskpath [hostname] [--debug] [-h|--help]
 Bootstrap a Raspberry Pi Compute Module for first-time AmpliPi setup.
 
   diskpath:   The path to the mounted raspberry pi disk. Should be /dev/sdX
-  hostname:   The hostname to set on the pi, so once this script successfully completes
-              connect via {hostname}.local. Default is amplipi
+  hostname:   The hostname to set on the pi, so once this script successfully
+              completes connect via {hostname}.local. Default is amplipi
+  --cli-only: Use the lite version of Raspberry Pi OS which does not have a
+              desktop environment
   --debug:    Will print all commands to be run and disable cleanup on exit
-  --desktop:  Use the desktop version of Raspberry Pi OS instead of the lite version
   -h, --help: Print this help text.
 "
 
@@ -17,11 +18,11 @@ hostname='amplipi'
 diskpath_set=false
 host_set=false
 debug=false
-desktop=false
+lite=false
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --debug) debug=true ;;
-    --desktop) desktop=true ;;
+    --cli-only) lite=true ;;
     -h|--help) printf "$helptext"; exit 0 ;;
     *) if ! $diskpath_set; then
         diskpath=$1
@@ -133,12 +134,12 @@ if ! [[ -e $diskpath ]]; then
   cleanup
 fi
 
-if $desktop; then
-  release=2020-08-20-raspios-buster-armhf
-  url=http://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2020-08-24/$release.zip
-else
+if $lite; then
   release=2020-08-20-raspios-buster-armhf-lite
   url=http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-08-24/$release.zip
+else
+  release=2020-08-20-raspios-buster-armhf
+  url=http://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2020-08-24/$release.zip
 fi
 zip_file=$HOME/Downloads/$release.zip
 if [[ ! -f $zip_file ]]; then

--- a/scripts/bootstrap_pi
+++ b/scripts/bootstrap_pi
@@ -2,10 +2,10 @@
 # Install AmpliPi from scratch on a new pi compute module
 # This script is mainly intended for MicroNova employees to bringup Pi's. Your AmpliPi device should already have this configuration.
 
-helptext="Usage: bootstrap_pi diskpath [hostname] [--debug] [-h|--help]
+helptext="Usage: bootstrap_pi diskpath [--hostname NAME] [--cli-only] [--debug] [-h|--help]
 Bootstrap a Raspberry Pi Compute Module for first-time AmpliPi setup.
 
-  hostname:   The hostname to set on the pi, so once this script successfully
+  --hostname: The hostname to set on the pi, so once this script successfully
               completes connect via {hostname}.local. Default is amplipi
   --cli-only: Use the lite version of Raspberry Pi OS which does not have a
               desktop environment
@@ -14,22 +14,25 @@ Bootstrap a Raspberry Pi Compute Module for first-time AmpliPi setup.
 "
 
 hostname='amplipi'
-host_set=false
 debug=false
 lite=false
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-    --debug) debug=true ;;
+    --hostname)
+        if (($# > 1)); then
+          hostname=$2; shift
+        else
+          printf "--hostname requires a second parameter\n\n"
+          printf "$helptext"
+          exit 1
+        fi
+      ;;
     --cli-only) lite=true ;;
+    --debug) debug=true ;;
     -h|--help) printf "$helptext"; exit 0 ;;
-    *) if ! $host_set; then
-        hostname=$1
-        host_set=true
-      else
-        echo "Unknown parameter passed: $1";
-        printf "$helptext";
+    *)  printf "Unknown parameter passed: $1\n\n"
+        printf "$helptext"
         exit 1
-      fi
       ;;
   esac
   shift
@@ -154,63 +157,85 @@ echo "Go get a coffee or something :)"
 sudo dd if=$release.img of=$diskpath bs=4MiB status=progress
 popd # $release
 
-echo "Editing some configuration"
-sudo mkdir -p /mnt/pi-boot
-sudo mkdir -p /mnt/pi-root
-echo "Made /mnt/pi-[br]oot, waiting a bit..."
-sleep 5
-echo "Mounting $diskpath-part1 at /mnt/pi-boot"
-#sudo mount ${diskpath}1 /mnt/pi-boot # boot partition
-#sudo mount ${diskpath}2 /mnt/pi-root # root filesystem partition
-sudo mount $diskpath-part1 /mnt/pi-boot # boot partition
-echo "Mounting $diskpath-part2 at /mnt/pi-boot"
-sudo mount $diskpath-part2 /mnt/pi-root # root filesystem partition
+# First arg is partition path to mount
+config_boot () {
+  sudo mkdir -p /mnt/pi-boot
+  sudo mount $1 /mnt/pi-boot # boot partition
+  pushd /mnt/pi-boot
 
-ls /mnt/pi-boot
-ls /mnt/pi-root
+  echo "Enabling SSH access"
+  sudo touch ssh
 
-pushd /mnt/pi-boot
+  # extra config to make sure the USB serial tty is disabled
+  # (we use this to communicate with the AmpliPi preamp)
+  echo "Disabling USB serial tty"
+  CMDLINE=cmdline.txt
+  sudo sed -i $CMDLINE -e "s/console=ttyAMA0,[0-9]\+ //"
+  sudo sed -i $CMDLINE -e "s/console=serial0,[0-9]\+ //"
 
-echo "Enabling SSH access"
-sudo touch ssh
+  popd # /mnt/pi-boot
+}
 
-# extra config to make sure the USB serial tty is disabled (we use this to communicate with the AmpliPi preamp)
-echo "Disabling USB serial tty"
-CMDLINE=cmdline.txt
-sudo sed -i $CMDLINE -e "s/console=ttyAMA0,[0-9]\+ //"
-sudo sed -i $CMDLINE -e "s/console=serial0,[0-9]\+ //"
+# First arg is partition path to mount
+config_root () {
+  sudo mkdir -p /mnt/pi-root
+  sudo mount $1 /mnt/pi-root # root filesystem partition
+  pushd /mnt/pi-root
 
-popd # /mnt/pi-boot
+  printf "Setting the hostname to "
+  echo $hostname | sudo tee etc/hostname
+  # need to change hostname reference too
+  # (if you don't it causes a message to be reported after every sudo)
+  sudo sed -i'' -e "s/raspberrypi/$hostname/" etc/hosts
 
-pushd /mnt/pi-root
+  # add pi user manually to dialout group, avoiding an additional restart
+  echo "Adding the pi user to the dialout group"
+  sudo sed -i'' -r -e 's/dialout:x:([0-9]+:.*)/dialout:x:\1,pi/' -e 's/:,pi/:pi/' -e 's/pi,pi/pi/' etc/group
 
-echo "Setting the hostname to $hostname"
-echo $hostname | sudo tee etc/hostname
-sudo sed -i'' -e "s/raspberrypi/$hostname/" etc/hosts # need to change hostname reference too (if you don't it causes a message to be reported after every sudo)
+  echo "Copying the pi's boot configuration"
+  sudo cp $amplipi_config_dir/boot_config.txt /mnt/pi-boot/config.txt
 
-# add pi user manually to dialout group, avoiding an additional restart
-echo "Adding the pi user to the dialout group"
-sudo sed -i'' -r -e 's/dialout:x:([0-9]+:.*)/dialout:x:\1,pi/' -e 's/:,pi/:pi/' -e 's/pi,pi/pi/' etc/group
+  # extra config to enable i2c (from do-i2c in raspi-config bash script)
+  BLACKLIST=etc/modprobe.d/raspi-blacklist.conf
+  if ! [ -e $BLACKLIST ]; then
+    sudo touch $BLACKLIST
+  fi
+  sudo sed $BLACKLIST -i -e "s/^\(blacklist[[:space:]]*i2c[-_]bcm2708\)/#\1/"
+  sudo sed etc/modules -i -e "s/^#[[:space:]]*\(i2c[-_]dev\)/\1/"
+  if ! grep -q "^i2c[-_]dev" etc/modules; then
+    printf "i2c-dev\n" | sudo tee -a etc/modules
+  fi
 
-echo "Copying the pi's boot configuration"
-sudo cp $amplipi_config_dir/boot_config.txt /mnt/pi-boot/config.txt
+  popd # /mnt/pi-root
+}
 
-# extra config to enable i2c (from do-i2c in raspi-config bash script)
-BLACKLIST=etc/modprobe.d/raspi-blacklist.conf
-if ! [ -e $BLACKLIST ]; then
-  sudo touch $BLACKLIST
+# it can take a second or two for the new partitions to show up
+printf "\nChecking for the new root and boot partitions\n"
+boot_part=false
+root_part=false
+for i in {1..10}; do
+  sleep 0.5
+  if ! $boot_part && [ -e $diskpath-part1 ]; then
+    boot_part=true
+    echo "Editing boot configuration"
+    config_boot $diskpath-part1
+  fi
+  if ! $root_part && [ -e $diskpath-part2 ]; then
+    root_part=true
+    echo "Editing root configuration"
+    config_root $diskpath-part2
+  fi
+  $boot_part && $root_part && break
+done
+if ! $boot_part || ! $root_part ; then
+  echo "Error: Failed to find boot and root partitions"
+  cleanup
 fi
-sudo sed $BLACKLIST -i -e "s/^\(blacklist[[:space:]]*i2c[-_]bcm2708\)/#\1/"
-sudo sed etc/modules -i -e "s/^#[[:space:]]*\(i2c[-_]dev\)/\1/"
-if ! grep -q "^i2c[-_]dev" etc/modules; then
-  printf "i2c-dev\n" | sudo tee -a etc/modules
-fi
 
-# cleanup
-popd # /mnt/pi-root
 popd # /tmp/*
 
-echo "Bootstrapping successful. Please complete the following steps:
+echo "
+Bootstrapping successful. Please complete the following steps:
   1. Disconnect the service USB cable.
   2. Unplug the AmpliPi unit.
   3. Plug it back in to power it on.

--- a/scripts/bootstrap_pi
+++ b/scripts/bootstrap_pi
@@ -9,6 +9,7 @@ Bootstrap a Raspberry Pi Compute Module for first-time AmpliPi setup.
   hostname:   The hostname to set on the pi, so once this script successfully completes
               connect via {hostname}.local. Default is amplipi
   --debug:    Will print all commands to be run and disable cleanup on exit
+  --desktop:  Use the desktop version of Raspberry Pi OS instead of the lite version
   -h, --help: Print this help text.
 "
 
@@ -16,9 +17,11 @@ hostname='amplipi'
 diskpath_set=false
 host_set=false
 debug=false
+desktop=false
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --debug) debug=true ;;
+    --desktop) desktop=true ;;
     -h|--help) printf "$helptext"; exit 0 ;;
     *) if ! $diskpath_set; then
         diskpath=$1
@@ -130,17 +133,21 @@ if ! [[ -e $diskpath ]]; then
   cleanup
 fi
 
-release=2020-08-20-raspios-buster-armhf-lite
-echo "Downloading and extracting Raspberry Pi OS"
-if [[ -f $HOME/Downloads/$release.zip ]] ; then
-  zip_file=$HOME/Downloads/$release.zip
+if $desktop; then
+  release=2020-08-20-raspios-buster-armhf
+  url=http://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2020-08-24/$release.zip
 else
-  wget http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-08-24/$release.zip
-  cp $release.zip ~/Downloads # save for later
-  zip_file=$release.zip
+  release=2020-08-20-raspios-buster-armhf-lite
+  url=http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-08-24/$release.zip
+fi
+zip_file=$HOME/Downloads/$release.zip
+if [[ ! -f $zip_file ]]; then
+  echo "Downloading Raspberry Pi OS"
+  wget $url -O $zip_file # save for later
 fi
 mkdir $release
 pushd $release
+echo "Extracting Raspberry Pi OS"
 unzip $zip_file
 
 if [[ -e $diskpath ]]; then

--- a/scripts/bootstrap_pi
+++ b/scripts/bootstrap_pi
@@ -5,7 +5,6 @@
 helptext="Usage: bootstrap_pi diskpath [hostname] [--debug] [-h|--help]
 Bootstrap a Raspberry Pi Compute Module for first-time AmpliPi setup.
 
-  diskpath:   The path to the mounted raspberry pi disk. Should be /dev/sdX
   hostname:   The hostname to set on the pi, so once this script successfully
               completes connect via {hostname}.local. Default is amplipi
   --cli-only: Use the lite version of Raspberry Pi OS which does not have a
@@ -15,7 +14,6 @@ Bootstrap a Raspberry Pi Compute Module for first-time AmpliPi setup.
 "
 
 hostname='amplipi'
-diskpath_set=false
 host_set=false
 debug=false
 lite=false
@@ -24,10 +22,7 @@ while [[ "$#" -gt 0 ]]; do
     --debug) debug=true ;;
     --cli-only) lite=true ;;
     -h|--help) printf "$helptext"; exit 0 ;;
-    *) if ! $diskpath_set; then
-        diskpath=$1
-        diskpath_set=true
-      elif ! $host_set; then
+    *) if ! $host_set; then
         hostname=$1
         host_set=true
       else
@@ -41,15 +36,6 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 $debug && set -x
-
-if ! $diskpath_set; then
-  printf "$helptext"
-  printf "\ndiskpath is required!\n"
-  printf "This script will exit after connecting to the pi and listing disks.\n"
-  printf "Re-run this script with the correct diskpath to bootstrap.\n"
-  read -p "Press any key to continue" -n 1
-  printf "\n"
-fi
 
 current_dir="$(dirname "$(realpath ${BASH_SOURCE[0]})")"
 amplipi_config_dir="$(realpath $current_dir/../config)"
@@ -111,6 +97,7 @@ fi
 
 make
 
+# instruct user on manual boot process
 echo -e "\nPlug in a usb cable from the service port to your computer. Keep AmpliPi Unplugged / Powered OFF for now."
 read -p "Press any key to continue" -n 1
 echo  # newline
@@ -118,19 +105,20 @@ read -p "Press any key and then plug in the AmpliPi" -n 1
 sudo ./rpiboot
 popd # usbboot
 
-print_disks () {
-  printf "\nListing available disks sorted by time.\n"
-  printf "The pi should be the first /dev/sdX.\n\n"
-  for d in $(ls -t -1 /dev/sd?); do
-    lsblk -plndo name,size $d
-  done
-}
-
-
-sleep 2 # TODO: how to determine the disk has been attached?
-if ! [[ -e $diskpath ]]; then
-  printf "\n$diskpath is not available\n"
-  print_disks
+# wait for the Raspberry Pi to connect
+# it will show up as 0a5c:2764 without usbboot
+# it will show up as 0a5c:0001 when mounting as /dev/sdX
+connected=false
+for i in {1..10}; do
+  sleep 0.5
+  if lsusb -d 0a5c:0001 >/dev/null; then
+    printf "Connected to Raspberry Pi!\n\n"
+    connected=true
+    break
+  fi
+done
+if ! $connected; then
+  echo "Error: Failed to connect to Raspberry Pi"
   cleanup
 fi
 
@@ -151,34 +139,43 @@ pushd $release
 echo "Extracting Raspberry Pi OS"
 unzip $zip_file
 
-if [[ -e $diskpath ]]; then
-  echo "Valid $diskpath device found"
-elif [[ ! -e $diskpath ]]; then
-  echo "ERROR: Expected device $diskpath not found"
-  print_disks
-  exit 1
+# Check for Raspberry Pi device path
+disk_base_path=/dev/disk/by-id/usb-RPi-MSD
+diskpath=$(ls $disk_base_path* 2>/dev/null | head -n1)
+if [ ! -z $diskpath ]; then
+  echo "Raspberry Pi device found at $diskpath"
 else
-  echo "ERROR: Can't handle the devices/partitions detected, maybe dd failed or other devices were detected"
-  print_disks
-  exit 1
+  echo "ERROR: No Raspberry Pi device found at $disk_base_path*"
 fi
 
-echo "Copying the image to the AmpliPi. This takes about 5 minutes. Go get a coffee or something :)"
-sudo dd if=$release.img of=$diskpath bs=4MiB
+$lite && est_time=5 || est_time=10
+echo "Copying the image to the AmpliPi. This takes about $est_time minutes."
+echo "Go get a coffee or something :)"
+sudo dd if=$release.img of=$diskpath bs=4MiB status=progress
 popd # $release
 
 echo "Editing some configuration"
 sudo mkdir -p /mnt/pi-boot
 sudo mkdir -p /mnt/pi-root
-sudo mount ${diskpath}1 /mnt/pi-boot # boot partition
-sudo mount ${diskpath}2 /mnt/pi-root # root filesystem partition
+echo "Made /mnt/pi-[br]oot, waiting a bit..."
+sleep 5
+echo "Mounting $diskpath-part1 at /mnt/pi-boot"
+#sudo mount ${diskpath}1 /mnt/pi-boot # boot partition
+#sudo mount ${diskpath}2 /mnt/pi-root # root filesystem partition
+sudo mount $diskpath-part1 /mnt/pi-boot # boot partition
+echo "Mounting $diskpath-part2 at /mnt/pi-boot"
+sudo mount $diskpath-part2 /mnt/pi-root # root filesystem partition
+
+ls /mnt/pi-boot
+ls /mnt/pi-root
 
 pushd /mnt/pi-boot
 
-# enable SSH access
+echo "Enabling SSH access"
 sudo touch ssh
 
 # extra config to make sure the USB serial tty is disabled (we use this to communicate with the AmpliPi preamp)
+echo "Disabling USB serial tty"
 CMDLINE=cmdline.txt
 sudo sed -i $CMDLINE -e "s/console=ttyAMA0,[0-9]\+ //"
 sudo sed -i $CMDLINE -e "s/console=serial0,[0-9]\+ //"
@@ -187,14 +184,15 @@ popd # /mnt/pi-boot
 
 pushd /mnt/pi-root
 
-# set the hostname to amplipi
+echo "Setting the hostname to $hostname"
 echo $hostname | sudo tee etc/hostname
 sudo sed -i'' -e "s/raspberrypi/$hostname/" etc/hosts # need to change hostname reference too (if you don't it causes a message to be reported after every sudo)
 
 # add pi user manually to dialout group, avoiding an additional restart
+echo "Adding the pi user to the dialout group"
 sudo sed -i'' -r -e 's/dialout:x:([0-9]+:.*)/dialout:x:\1,pi/' -e 's/:,pi/:pi/' -e 's/pi,pi/pi/' etc/group
 
-# copy the pi's boot configuration
+echo "Copying the pi's boot configuration"
 sudo cp $amplipi_config_dir/boot_config.txt /mnt/pi-boot/config.txt
 
 # extra config to enable i2c (from do-i2c in raspi-config bash script)


### PR DESCRIPTION
- Default to desktop Raspberry Pi OS image, but allow lite version with --cli-only flag
- Remove `diskpath` option and instead use `/dev/disk/by-id/usb-RPi-MSD*` to identify the Pi.
  TODO: This needs further testing with a second Pi.
- Replace simple delays with checks to verify next step is ready.
  - Check for USB VID:PID before trying to write image
  - Check for the boot and root partitions before trying to mount them
- I keep accidentally setting the hostname to some random fat-fingered parameter setting, so I made it `--hostname HOSTNAME` instead of just `HOSTNAME`. My sanity has vastly improved.