### PR TITLE
DAC volume level equalization

### DIFF
--- a/config/asound.conf
+++ b/config/asound.conf
@@ -1,14 +1,23 @@
-# i2s sndrpihifiberry
-pcm.ch0 {
-    type plug # autonegotiate connection bitrates/mono/stereo
-    slave {
-      pcm "hw:sndrpihifiberry,0"
-    }
+# Default to playing to source 0
+pcm.!default {
+    type plug
+    slave.pcm       "ch0"
 }
 
-ctl.ch0 {
-   type hw
-   card sndrpihifiberry
+# I2S sndrpihifiberry
+pcm.i2sdac {
+    type plug # Autonegotiate connection bitrates/mono/stereo
+    slave.pcm       "hw:sndrpihifiberry,0"
+}
+
+# Use softvol since the DAC doesn't have volume support
+pcm.ch0 {
+    type            softvol
+    slave.pcm       "i2sdac"
+    control {
+        name        "Master Playback Volume"
+        card        sndrpihifiberry
+    }
 }
 
 # USB

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -1,27 +1,22 @@
 # Default to playing to source 0
 pcm.!default {
-    type plug
+    type            plug
     slave.pcm       "ch0"
 }
 
-# Use plug to autonegotiate connection bitrate and mono/stereo
+# Use softvol since the DAC doesn't have volume support
 pcm.i2sdac {
-    type            plug
+    type            softvol
     slave.pcm       "hw:sndrpihifiberry,0"
+    control.name    "Master Playback Volume"
+    control.card     sndrpihifiberry
+    max_dB          -7.2
 }
 
-# Use softvol since the DAC doesn't have volume support
 pcm.ch0 {
-    type            softvol
+    type            plug # autonegotiate connection bitrates/mono/stereo
     slave.pcm       "i2sdac"
-    control {
-        name        "Master Playback Volume"
-        card        sndrpihifiberry
-    }
 }
-# TODO: Set max to 219/255 [86%] [-7.20dB]
-# amixer -D ch0 sset Master 219
-# DAC pk-pk output: 2.2V
 
 ctl.ch0 {
     type            hw
@@ -29,23 +24,20 @@ ctl.ch0 {
 }
 
 # USB
-# TODO: Set max to 122/197 [62%] [-14.06dB]
-# amixer -D usb71 sset Speaker 122
-# DAC pk-pk output: 2.2V
 pcm.usb71 {
-    type hw
-    card cmedia8chint
+    type            hw
+    card            cmedia8chint
 }
 
 ctl.usb71 {
-    type hw
-    card cmedia8chint
+    type            hw
+    card            cmedia8chint
 }
 
 pcm.dmixer {
-    type dmix
-    ipc_key 1024
-    ipc_perm 0666
+    type            dmix
+    ipc_key         1024
+    ipc_perm        0666
     slave {
         pcm         "usb71"
         period_time 0
@@ -65,47 +57,74 @@ pcm.dmixer {
     }
 }
 
-#pcm.!default {
-#    type plug
-#    slave {
-#        pcm "dmixer"
-#        channels 8
-#    }
-#    ttable.0.0 1
-#    ttable.1.1 1
-#    ttable.0.2 1
-#    ttable.1.3 1
-#    ttable.0.4 1
-#    ttable.1.5 1
-#    ttable.0.6 1
-#    ttable.1.7 1
-#}
-
 pcm.ch1 {
-    type plug
-    slave {
-        pcm "dmixer"
-        channels 8
-    }
-    ttable.0.6 1
-    ttable.1.7 1
+    type            plug
+    slave.pcm       "dmixer"
+    slave.channels  8
+    ttable.0.6      0.63
+    ttable.1.7      0.63
 }
 pcm.ch2 {
-    type plug
-    slave {
-        pcm "dmixer"
-        channels 8
-    }
-    ttable.0.0 1
-    ttable.1.1 1
+    type            plug
+    slave.pcm       "dmixer"
+    slave.channels  8
+    ttable.0.0      0.63
+    ttable.1.1      0.63
 }
 pcm.ch3 {
-    type plug
-    slave {
-        pcm "dmixer"
-        channels 8
-    }
-    ttable.0.4 1
-    ttable.1.5 1
+    type            plug
+    slave.pcm       "dmixer"
+    slave.channels  8
+    ttable.0.4      0.63
+    ttable.1.5      0.63
 }
-# TODO: volume controls for individual channels?
+
+pcm.ch0123_multi {
+    type multi
+    slaves {
+        a.pcm       "ch0"
+        a.channels  2
+        b.pcm       "ch1"
+        b.channels  2
+        c.pcm       "ch2"
+        c.channels  2
+        d.pcm       "ch3"
+        d.channels  2
+    }
+    bindings {
+        0.slave     a
+        0.channel   0
+        1.slave     a
+        1.channel   1
+
+        2.slave     b
+        2.channel   0
+        3.slave     b
+        3.channel   1
+
+        4.slave     c
+        4.channel   0
+        5.slave     c
+        5.channel   1
+
+        6.slave     d
+        6.channel   0
+        7.slave     d
+        7.channel   1
+    }
+}
+
+# 1x stereo -> 4x stereo
+pcm.ch0123 {
+    type            route
+    slave.pcm       "ch0123_multi"
+    slave.channels  8
+    ttable.0.0      1
+    ttable.1.1      1
+    ttable.0.2      1
+    ttable.1.3      1
+    ttable.0.4      1
+    ttable.1.5      1
+    ttable.0.6      1
+    ttable.1.7      1
+}

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -1,14 +1,3 @@
-# headphones
-pcm.headphones_unused {
-   type hw
-   card 0
-}
-
-ctl.headphones_unused {
-   type hw
-   card 0
-}
-
 # i2s sndrpihifiberry
 pcm.ch0 {
     type plug # autonegotiate connection bitrates/mono/stereo

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -1,3 +1,6 @@
+# AmpliPi ALSA config
+# Place in /etc/asound.conf
+
 # Default to playing to source 0
 pcm.!default {
     type            plug
@@ -10,11 +13,29 @@ pcm.i2sdac {
     slave.pcm       "hw:sndrpihifiberry,0"
     control.name    "Master Playback Volume"
     control.card     sndrpihifiberry
-    max_dB          -7.2
+
+    # Set the max_dB to avoid clipping on the negative side of the preamp's
+    # U2/U4/U6/U8 op-amps. The audio signal is centered at 2.5 V and the
+    # op-amps cleanly pass down to ~1.4V, so max (2.5 - 1.4) / sqrt(2)
+    # = 0.78 Vrms. Nominal (max_dB = 0) DAC output is ~1.7 Vrms.
+    # 20*log10(0.78/1.7) ~= -6.8 dBV
+    max_dB          -6.8
+
+    # For now leaving at -6.8 dB to maximize SNR before the amplifiers,
+    # and to leave some headroom for per-zone attenuation settings.
+    # If clipping of the amplifiers is to be fully avoided, reduce further:
+    # Max amp power output: 79 W @ 4 Ohms
+    # Max amp Vrms = sqrt(79*4) = 17.8 V = 25 dBV
+    # Amp gain = 32.8 dBV
+    # Max amp input = 25 dBV - 32.8 dBV = -7.8 dBV = 0.41 Vrms
+    # max_dB = 20*log10(0.41/1.7) = -12.4
+
 }
 
+# Create source 0 which streams to the softvol plugin.
+# Use type plug to autonegotiate connection bitrates/mono/stereo.
 pcm.ch0 {
-    type            plug # autonegotiate connection bitrates/mono/stereo
+    type            plug
     slave.pcm       "i2sdac"
 }
 
@@ -23,7 +44,7 @@ ctl.ch0 {
     card            sndrpihifiberry
 }
 
-# USB
+# CM6206 USB audio DAC/ADC
 pcm.usb71 {
     type            hw
     card            cmedia8chint
@@ -34,6 +55,8 @@ ctl.usb71 {
     card            cmedia8chint
 }
 
+# Only 1 client can use 'usb71' directly at a time.
+# The dmix plugin allows multiple client connections at a time and mixes them.
 pcm.dmixer {
     type            dmix
     ipc_key         1024
@@ -57,29 +80,35 @@ pcm.dmixer {
     }
 }
 
+# Create sources 1-3 as individual stereo streams
+# Attenuate to 64% before sending to mixer to avoid op-amp clipping
+#   Attenuate to 28% to avoid amplifier clipping
+#   For now leaving at 64% to maximize SNR before the amplifiers, and to leave
+#   some headroom for per-zone attenuation settings
 pcm.ch1 {
     type            plug
     slave.pcm       "dmixer"
     slave.channels  8
-    ttable.0.6      0.63
-    ttable.1.7      0.63
+    ttable.0.6      0.64
+    ttable.1.7      0.64
 }
 pcm.ch2 {
     type            plug
     slave.pcm       "dmixer"
     slave.channels  8
-    ttable.0.0      0.63
-    ttable.1.1      0.63
+    ttable.0.0      0.64
+    ttable.1.1      0.64
 }
 pcm.ch3 {
     type            plug
     slave.pcm       "dmixer"
     slave.channels  8
-    ttable.0.4      0.63
-    ttable.1.5      0.63
+    ttable.0.4      0.64
+    ttable.1.5      0.64
 }
 
-pcm.ch0123_multi {
+# Bind all 4 stereo sources into one 4-channel stereo stream
+pcm.ch0123_4ch {
     type multi
     slaves {
         a.pcm       "ch0"
@@ -114,10 +143,10 @@ pcm.ch0123_multi {
     }
 }
 
-# 1x stereo -> 4x stereo
+# Duplicate one stereo stream into one 4-channel stereo stream
 pcm.ch0123 {
     type            route
-    slave.pcm       "ch0123_multi"
+    slave.pcm       "ch0123_4ch"
     slave.channels  8
     ttable.0.0      1
     ttable.1.1      1

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -4,9 +4,9 @@ pcm.!default {
     slave.pcm       "ch0"
 }
 
-# I2S sndrpihifiberry
+# Use plug to autonegotiate connection bitrate and mono/stereo
 pcm.i2sdac {
-    type plug # Autonegotiate connection bitrates/mono/stereo
+    type            plug
     slave.pcm       "hw:sndrpihifiberry,0"
 }
 
@@ -19,8 +19,19 @@ pcm.ch0 {
         card        sndrpihifiberry
     }
 }
+# TODO: Set max to 219/255 [86%] [-7.20dB]
+# amixer -D ch0 sset Master 219
+# DAC pk-pk output: 2.2V
+
+ctl.ch0 {
+    type            hw
+    card            sndrpihifiberry
+}
 
 # USB
+# TODO: Set max to 122/197 [62%] [-14.06dB]
+# amixer -D usb71 sset Speaker 122
+# DAC pk-pk output: 2.2V
 pcm.usb71 {
     type hw
     card cmedia8chint
@@ -35,12 +46,12 @@ pcm.dmixer {
     type dmix
     ipc_key 1024
     ipc_perm 0666
-    slave.pcm "usb71"
     slave {
+        pcm         "usb71"
         period_time 0
         period_size 1024
         buffer_size 4096
-        channels 8
+        channels    8
     }
     bindings {
         0 0
@@ -54,23 +65,22 @@ pcm.dmixer {
     }
 }
 
-pcm.!default {
-    type plug
-    slave {
-        pcm "dmixer"
-        channels 8
-    }
-    ttable.0.0 1
-    ttable.1.1 1
-    ttable.0.2 1
-    ttable.1.3 1
-    ttable.0.4 1
-    ttable.1.5 1
-    ttable.0.6 1
-    ttable.1.7 1
-}
+#pcm.!default {
+#    type plug
+#    slave {
+#        pcm "dmixer"
+#        channels 8
+#    }
+#    ttable.0.0 1
+#    ttable.1.1 1
+#    ttable.0.2 1
+#    ttable.1.3 1
+#    ttable.0.4 1
+#    ttable.1.5 1
+#    ttable.0.6 1
+#    ttable.1.7 1
+#}
 
-### Controller v1
 pcm.ch1 {
     type plug
     slave {
@@ -79,7 +89,8 @@ pcm.ch1 {
     }
     ttable.0.6 1
     ttable.1.7 1
-}pcm.ch2 {
+}
+pcm.ch2 {
     type plug
     slave {
         pcm "dmixer"
@@ -87,7 +98,8 @@ pcm.ch1 {
     }
     ttable.0.0 1
     ttable.1.1 1
-}pcm.ch3 {
+}
+pcm.ch3 {
     type plug
     slave {
         pcm "dmixer"
@@ -96,46 +108,4 @@ pcm.ch1 {
     ttable.0.4 1
     ttable.1.5 1
 }
-
-### Old prototype configuration
-#
-##pcm.ch0 {
-##    type plug
-##    slave {
-##        pcm "dmixer"
-##        channels 8
-##    }
-##    ttable.0.4 1
-##    ttable.1.5 1
-##}
-##
-#
-#pcm.ch1 {
-#    type plug
-#    slave {
-#        pcm "dmixer"
-#        channels 8
-#    }
-#    ttable.0.0 1
-#    ttable.1.1 1
-#}
-#
-#pcm.ch2 {
-#    type plug
-#    slave {
-#        pcm "dmixer"
-#        channels 8
-#    }
-#    ttable.0.6 1
-#    ttable.1.7 1
-#}
-#
-#pcm.ch3 {
-#    type plug
-#    slave {
-#        pcm "dmixer"
-#        channels 8
-#    }
-#    ttable.0.2 1
-#    ttable.1.3 1
-#}
+# TODO: volume controls for individual channels?

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -157,3 +157,12 @@ pcm.ch0123 {
     ttable.0.6      1
     ttable.1.7      1
 }
+
+# Duplicate a mono stream to stereo
+pcm.ch0m2s {
+    type            route
+    slave.pcm       "ch0"
+    slave.channels  2
+    ttable.0.0      1
+    ttable.0.1      1
+}

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -107,58 +107,8 @@ pcm.ch3 {
     ttable.1.5      0.64
 }
 
-# Bind all 4 stereo sources into one 4-channel stereo stream
-pcm.ch0123_4ch {
-    type multi
-    slaves {
-        a.pcm       "ch0"
-        a.channels  2
-        b.pcm       "ch1"
-        b.channels  2
-        c.pcm       "ch2"
-        c.channels  2
-        d.pcm       "ch3"
-        d.channels  2
-    }
-    bindings {
-        0.slave     a
-        0.channel   0
-        1.slave     a
-        1.channel   1
-
-        2.slave     b
-        2.channel   0
-        3.slave     b
-        3.channel   1
-
-        4.slave     c
-        4.channel   0
-        5.slave     c
-        5.channel   1
-
-        6.slave     d
-        6.channel   0
-        7.slave     d
-        7.channel   1
-    }
-}
-
-# Duplicate one stereo stream into one 4-channel stereo stream
-pcm.ch0123 {
-    type            route
-    slave.pcm       "ch0123_4ch"
-    slave.channels  8
-    ttable.0.0      1
-    ttable.1.1      1
-    ttable.0.2      1
-    ttable.1.3      1
-    ttable.0.4      1
-    ttable.1.5      1
-    ttable.0.6      1
-    ttable.1.7      1
-}
-
-# Duplicate a mono stream to stereo
+# Duplicate a mono stream to stereo for testing, since
+# `speaker-test` only plays one mono output at a time.
 pcm.ch0m2s {
     type            route
     slave.pcm       "ch0"

--- a/config/boot_config.txt
+++ b/config/boot_config.txt
@@ -47,14 +47,7 @@ dtparam=i2c_arm=on, i2c_arm_baudrate=50000
 dtparam=i2s=on
 dtparam=spi=on
 
-# Uncomment this to enable infrared communication.
-#dtoverlay=gpio-ir,gpio_pin=17
-#dtoverlay=gpio-ir-tx,gpio_pin=18
-
 # Additional overlays and parameters are documented /boot/overlays/README
-
-# Enable audio (loads snd_bcm2835)
-dtparam=audio=on
 
 [pi4]
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack


### PR DESCRIPTION
Attenuated the I2S and USB DAC's output to avoid op-amp clipping. This also makes the I2S and USB DACs output the same levels.