### PR TITLE
Add back button to updater

### DIFF
--- a/amplipi/updater/static/css/styles.css
+++ b/amplipi/updater/static/css/styles.css
@@ -3,9 +3,12 @@
  */
 body {
   padding-bottom: 2rem;
-  padding-top: 4rem;
+  padding-top: 1rem;
   color: white;
   background-color: #2a2a2a;
+}
+h1 {
+  font-size: 3rem;
 }
 .row {
   margin-bottom: 1rem;

--- a/amplipi/updater/static/index.html
+++ b/amplipi/updater/static/index.html
@@ -23,7 +23,9 @@
   <body>
 
     <main role="main" class="container">
-
+      <p class="">
+        <a id="back-to-app" class="btn btn-primary btn-sm text-center" role="button" href="/" onclick="javascript:event.target.port=80"><i class="fa fa-arrow-left"></i> Back to App</a>
+      </p>
       <h1><span class="text-white">Ampli</span><span class="text-danger">Pi</span></h1>
       <p class="lead mb-4">
         Update your AmpliPi device

--- a/amplipi/updater/static/js/update-ui.js
+++ b/amplipi/updater/static/js/update-ui.js
@@ -139,6 +139,7 @@ function ui_upload_software_update() {
 }
 
 function ui_disable_buttons() {
+  $('#back-to-app').addClass('disabled');
   $('#submit-latest-update, #submit-older-update, #submit-custom-update').addClass('disabled');
   $('#submit-latest-update, #submit-older-update, #submit-custom-update').empty().append('Updating <i class="fas fa-circle-notch"></i>');
   $('#older-update-sel, #update-file-selector').attr('disabled', '');
@@ -150,6 +151,7 @@ function ui_show_done() {
 }
 
 function ui_show_failure() {
+  $('#back-to-app').removeClass('disabled');
   $('#submit-latest-update, #submit-older-update, #submit-custom-update').removeClass('btn-primary').addClass('btn-danger');
   $('#submit-latest-update, #submit-older-update, #submit-custom-update').empty().append('Failed, Retry?');
   $('#submit-latest-update, #submit-older-update, #submit-custom-update').attr('onclick', 'window.location.reload(true)');


### PR DESCRIPTION
This allows users to easily get back to their AmpliPi app even if they don't have access to a back button. This should make updates easier in the Android App, where back exits the app.