### PR TITLE
Add refresh on zone display mismatch

### DIFF
--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -63,7 +63,14 @@ function debounce(ms, fun){
 function refresh() {
   get();
 }
-current_src = 's0';
+current_src = 's0'; // this needs to be set base on the URL path
+for (var i = 0; i < 4; i++) {
+  if (window.location.href.endsWith(`/${i}`)) {
+    current_src = `s${i}`;
+    break;
+  }
+}
+
 $(document).ready(function(){
   // Some things are not part of the automatic tab-content switching
   // hide things related to the old src and show things related to the new one

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -312,7 +312,7 @@ function updateSourceView(status) {
       let z = ctrl.dataset.zone;
       const zone = status.zones[z];
       updateVol(ctrl, zone.mute, zone.vol);
-      parent_src = ctrl.parentElement.parentElement.parentElement.id.replace('-groups', '').replace('s', '');
+      parent_src = ctrl.dataset.source;
       if (zone.source_id != parent_src) {
         zone_mismatch = true;
       }

--- a/web/templates/index.html.j2
+++ b/web/templates/index.html.j2
@@ -226,7 +226,7 @@
             <h6 class="card-header"><i class="fas fa-chevron-down"></i> {{ group['name'] }}</h6>
           </a>
           <div class="card-body">
-            <div id="g{{ group['id'] }}-vol" class="volume {% if group['mute'] %} muted {% endif %}"  data-group="{{ group['id'] }}">
+            <div id="g{{ group['id'] }}-vol" class="volume {% if group['mute'] %} muted {% endif %}"  data-group="{{ group['id'] }}" data-source="{{src}}">
               <input type="range" min="-79" max="0" value="{{ group['vol_delta'] }}" class="volume-range">
               <div class="icon" onclick="debounce(250, onMuteToggle)(this);">
                 <i class="fa {% if group['mute'] %} fa-volume-mute {% else %} fa-volume-up {% endif %} icon-size" aria-hidden="true"></i>
@@ -244,7 +244,7 @@
               <div class="card zone">
                 <h6 class="card-header">{{ zone['name'] }}</h6>
                 <div class="card-body">
-                  <div id="g{{ group['id'] }}-z{{ zone['id'] }}-vol" class="volume {% if zone['mute'] %} muted {% endif %}" data-zone="{{ zone['id'] }}">
+                  <div id="g{{ group['id'] }}-z{{ zone['id'] }}-vol" class="volume {% if zone['mute'] %} muted {% endif %}" data-zone="{{ zone['id'] }}"  data-source="{{src}}">
                     <input type="range" min="-79" max="0" value="{{ zone['vol'] }}" class="volume-range">
                     <div class="icon" onclick="debounce(250, onMuteToggle)(this);">
                       <i class="fa {% if zone['mute'] %} fa-volume-mute {% else %} fa-volume-up {% endif %} icon-size" aria-hidden="true"></i>
@@ -266,7 +266,7 @@
         <div class="card ungrouped-zone">
           <h6 class="card-header">{{ zone['name'] }}</h6>
           <div class="card-body">
-            <div id="z{{ zone['id'] }}-vol" class="volume {% if zone['mute'] %} muted {% endif %}" data-zone="{{ zone['id'] }}">
+            <div id="z{{ zone['id'] }}-vol" class="volume {% if zone['mute'] %} muted {% endif %}" data-zone="{{ zone['id'] }}" data-source="{{src}}">
               <input type="range" min="-79" max="0" value="{{ zone['vol'] }}" class="volume-range">
               <div class="icon" onclick="debounce(250, onMuteToggle)(this);">
                 <i class="fa {% if zone['mute'] %} fa-volume-mute {% else %} fa-volume-up {% endif %} icon-size" aria-hidden="true"></i>


### PR DESCRIPTION
Make zones display update when they are moved from one source to another.

To test:
1. Open two instances of the AmpliPi app ( on your phone and also on your browser?)
2. Add a zone to a different source in app 1
3. Verify that app 2 updates to display the new zone 