### PR TITLE
I2C Arbitration Lost Fix

### DIFF
--- a/fw/preamp/src/adc.c
+++ b/fw/preamp/src/adc.c
@@ -74,6 +74,15 @@ Temps temps_ = {0};
 
 uint8_t hv1_f2_ = 0;
 
+void initAdc() {
+  // Write ADC setup byte
+  // REG=1 (setup byte), SEL[2:0] = 000 (VDD), CLK = 0 (internal),
+  // BIP/UNI=0 (unipolar), RST=0 (reset config register), X=0 (don't care)
+  uint32_t result = writeByteI2C2(adc_dev_, 0x80);
+  // TODO: Handle errors here
+  (void)result;
+}
+
 // TODO: Make standard i2c function
 AdcVals readAdc() {
   /****************************************************************************
@@ -127,7 +136,7 @@ void updateAdc() {
 #define ADC_REF_VOLTS 3.3
 #define ADC_PD_KOHMS  4700
 #define ADC_PU_KOHMS  100000
-  // TODO: low-pass filter after intial reading
+  // TODO: low-pass filter after initial reading
   AdcVals adc = readAdc();
 
   // Convert HV1 to Volts (multiply by 4 to add 2 fractional bits)

--- a/fw/preamp/src/adc.h
+++ b/fw/preamp/src/adc.h
@@ -24,6 +24,7 @@
 
 #include <stdint.h>
 
+void initAdc();
 void updateAdc();
 
 uint8_t getHV1_f2();

--- a/fw/preamp/src/audio.c
+++ b/fw/preamp/src/audio.c
@@ -56,7 +56,13 @@ uint8_t vol_req_[NUM_ZONES] = {VOL_MUTE};
 // The TDA7448 volume controller always reports 0x00 on read
 uint8_t vol_[NUM_ZONES] = {0};
 
-// If only preouts are used, the amplifier for a zone can be disabled
+// If any zone uses only the preout, the amp can be 'disabled' which will
+// remove it from consideration for leaving standby.
+// For example, consider zone 1 is 'disabled' but the rest are 'enabled'.
+// If zone 1 is the only zone unmuted, the amps will remain in standby.
+// The amps will exit standby if any other zone becomes unmuted.
+// A second example:
+// If all amps are 'disabled', then the amps will always remain in standby.
 bool amp_en_[NUM_ZONES] = {};
 
 // Convert a requested dB to the corresponding volume IC register value.

--- a/fw/preamp/src/audio.h
+++ b/fw/preamp/src/audio.h
@@ -49,6 +49,8 @@ void mute(size_t zone, bool mute);
 bool muted(size_t zone);
 bool inStandby();
 
+void    enZoneAmp(size_t zone, bool en);
+bool    zoneAmpEnabled(size_t zone);
 void    setZoneVolume(size_t zone, uint8_t vol);
 uint8_t getZoneVolume(size_t zone);
 void    setZoneSource(size_t zone, size_t src);

--- a/fw/preamp/src/ctrl_i2c.c
+++ b/fw/preamp/src/ctrl_i2c.c
@@ -41,7 +41,7 @@ typedef enum
   REG_ZONE321   = 0x01,
   REG_ZONE654   = 0x02,
   REG_MUTE      = 0x03,
-  REG_STANDBY   = 0x04,
+  REG_AMP_EN    = 0x04,
   REG_VOL_ZONE1 = 0x05,
   REG_VOL_ZONE2 = 0x06,
   REG_VOL_ZONE3 = 0x07,
@@ -137,8 +137,12 @@ uint8_t readReg(uint8_t addr) {
       }
       break;
 
-    case REG_STANDBY:
-      out_msg = inStandby() ? 0x3F : 0;
+    case REG_AMP_EN:
+      for (size_t zone = 0; zone < NUM_ZONES; zone++) {
+        if (zoneAmpEnabled(zone)) {
+          out_msg |= (1 << zone);
+        }
+      }
       break;
 
     case REG_VOL_ZONE1:
@@ -268,6 +272,12 @@ void writeReg(uint8_t addr, uint8_t data) {
     case REG_MUTE:
       for (size_t zone = 0; zone < NUM_ZONES; zone++) {
         mute(zone, data & (0x1 << zone));
+      }
+      break;
+
+    case REG_AMP_EN:
+      for (size_t zone = 0; zone < NUM_ZONES; zone++) {
+        enZoneAmp(zone, (data & (0x1 << zone)));
       }
       break;
 

--- a/fw/preamp/src/ctrl_i2c.c
+++ b/fw/preamp/src/ctrl_i2c.c
@@ -216,10 +216,9 @@ uint8_t readReg(uint8_t addr) {
       out_msg = getFanDuty();
       break;
 
-    case REG_FAN_VOLTS: {
+    case REG_FAN_VOLTS:
       out_msg = getFanVolts();
       break;
-    }
 
     case REG_VERSION_MAJOR:
       out_msg = VERSION_MAJOR_;

--- a/fw/preamp/src/ctrl_i2c.c
+++ b/fw/preamp/src/ctrl_i2c.c
@@ -72,17 +72,13 @@ typedef enum
   REG_GIT_HASH_0_D  = 0xFF,
 } CmdReg;
 
-/* Measured rise and fall times of the controller I2C bus
+/* Measured rise and fall times of the controller I2C bus.
+ * Rise time is from 30% to 70%.
  *
- * Single AmpliPi unit:
- *  t_r = ~370 ns
- *  t_f = ~5.3 ns
- * Single expansion unit:
- *  t_r = ~450 ns
- *  t_f = ~7.2 ns
- * Two expansion units:
- *  t_r = ~600 ns
- *  t_f = ~9.4 ns
+ * (ns)| Main | 1 Exp | 2 Exp | 3 Exp | 4 Exp | 5 Exp |
+ * ----+------+-------+-------+-------+-------+-------+
+ * t_r |  260 |   420 |   590 |   720 |   880 |  1000 |
+ * t_f | 16.4 |  16.4 |  16.4 |  17.2 |  19.6 |  20.0 |
  */
 void ctrlI2CInit() {
   // addr must be a 7-bit I2C address shifted left by one, ie: 0bXXXXXXX0

--- a/fw/preamp/src/ctrl_i2c.c
+++ b/fw/preamp/src/ctrl_i2c.c
@@ -273,7 +273,8 @@ void writeReg(uint8_t addr, uint8_t data) {
 
     case REG_AMP_EN:
       for (size_t zone = 0; zone < NUM_ZONES; zone++) {
-        enZoneAmp(zone, (data & (0x1 << zone)));
+        bool enable = data & (0x1 << zone);
+        enZoneAmp(zone, enable);
       }
       break;
 

--- a/fw/preamp/src/i2c.c
+++ b/fw/preamp/src/i2c.c
@@ -20,6 +20,7 @@
 
 #include "i2c.h"
 
+#include "pins.h"
 #include "stm32f0xx.h"
 
 // addr must be a 7-bit I2C address shifted left by one, ie: 0bXXXXXXX0
@@ -73,6 +74,19 @@ void initI2C2() {
   I2C_InitStructure2.I2C_Timing = 0x0010020B;
   I2C_Init(I2C2, &I2C_InitStructure2);
   I2C_Cmd(I2C2, ENABLE);
+
+  configI2C2Pins();
+}
+
+void deinitI2C2() {
+  /* Disable I2C2 and release GPIO control */
+
+  // Ensure I2C clock is enabled
+  RCC_APB1PeriphClockCmd(RCC_APB1Periph_I2C2, ENABLE);
+
+  // Disable I2C2 peripheral and release pins back to GPIO
+  I2C_Cmd(I2C2, DISABLE);
+  configI2C2PinsAsGPIO();
 }
 
 uint8_t readRegI2C2(I2CReg r) {

--- a/fw/preamp/src/i2c.c
+++ b/fw/preamp/src/i2c.c
@@ -20,7 +20,6 @@
 
 #include "i2c.h"
 
-#include "pins.h"
 #include "stm32f0xx.h"
 
 // addr must be a 7-bit I2C address shifted left by one, ie: 0bXXXXXXX0
@@ -74,8 +73,6 @@ void initI2C2() {
   I2C_InitStructure2.I2C_Timing = 0x0010020B;
   I2C_Init(I2C2, &I2C_InitStructure2);
   I2C_Cmd(I2C2, ENABLE);
-
-  configI2C2Pins();
 }
 
 void deinitI2C2() {
@@ -84,9 +81,8 @@ void deinitI2C2() {
   // Ensure I2C clock is enabled
   RCC_APB1PeriphClockCmd(RCC_APB1Periph_I2C2, ENABLE);
 
-  // Disable I2C2 peripheral and release pins back to GPIO
+  // Disable I2C2 peripheral
   I2C_Cmd(I2C2, DISABLE);
-  configI2C2PinsAsGPIO();
 }
 
 uint8_t readRegI2C2(I2CReg r) {

--- a/fw/preamp/src/i2c.c
+++ b/fw/preamp/src/i2c.c
@@ -43,18 +43,11 @@ void initI2C1(uint8_t addr) {
   I2C_Cmd(I2C1, ENABLE);
 }
 
+/* Init the second I2C bus. I2C2 is internal to a single AmpliPi unit.
+ * The STM32 is the master and controls the volume chips, power, fans,
+ * and front panel LEDs.
+ */
 void initI2C2() {
-  /* I2C-2 is internal to a single AmpliPi unit.
-   * The STM32 is the master and controls the volume chips, power, fans,
-   * and front panel LEDs.
-   *
-   * See the STM32F030 reference manual section 22.4.9 "I2C master mode" or
-   * AN4235 for I2C timing calculations.
-   * Excel tool, rise/fall 72/4 ns: 100 kHz: 0x00201D2C (0.5074% error)
-   *                                400 kHz: 0x0010020B (1.9992% error)
-   * Full math done in i2c_calcs.md
-   */
-
   // Enable peripheral clock for I2C2
   RCC_APB1PeriphClockCmd(RCC_APB1Periph_I2C2, ENABLE);
 
@@ -70,15 +63,21 @@ void initI2C2() {
   I2C_InitStructure2.I2C_Ack                 = I2C_Ack_Enable;
   I2C_InitStructure2.I2C_AcknowledgedAddress = I2C_AcknowledgedAddress_7bit;
 
+  /* See the STM32F030 reference manual section 22.4.9 "I2C master mode" or
+   * AN4235 for I2C timing calculations.
+   * Excel tool, rise/fall 72/4 ns: 100 kHz: 0x00201D2C (0.5074% error)
+   *                                400 kHz: 0x0010020B (1.9992% error)
+   * Full math done in i2c_calcs.md
+   */
   I2C_InitStructure2.I2C_Timing = 0x0010020B;
   I2C_Init(I2C2, &I2C_InitStructure2);
   I2C_Cmd(I2C2, ENABLE);
 }
 
+/* Disable the I2C2 peripheral */
 void deinitI2C2() {
-  /* Disable I2C2 and release GPIO control */
-
-  // Ensure I2C clock is enabled
+  // Ensure I2C peripheral clock is enabled in case this function is called
+  // before the I2C init function.
   RCC_APB1PeriphClockCmd(RCC_APB1Periph_I2C2, ENABLE);
 
   // Disable I2C2 peripheral
@@ -86,6 +85,8 @@ void deinitI2C2() {
 }
 
 uint32_t writeByteI2C2(I2CDev dev, uint8_t val) {
+  // TODO: Add timeout conditions for all while loops
+
   // Wait if I2C2 is busy
   while (I2C2->ISR & I2C_ISR_BUSY) {}
 
@@ -121,7 +122,7 @@ uint32_t writeByteI2C2(I2CDev dev, uint8_t val) {
 }
 
 uint8_t readRegI2C2(I2CReg r) {
-  uint8_t data;
+  // TODO: Add timeout conditions for all while loops
 
   // Wait if I2C2 is busy
   while (I2C_GetFlagStatus(I2C2, I2C_FLAG_BUSY)) {}
@@ -145,7 +146,7 @@ uint8_t readRegI2C2(I2CReg r) {
 
   // Wait until we get the rx data then read it out
   while (I2C_GetFlagStatus(I2C2, I2C_FLAG_RXNE) == RESET) {}
-  data = I2C_ReceiveData(I2C2);
+  uint8_t data = I2C_ReceiveData(I2C2);
 
   // Wait for stop condition to get sent then clear it
   while (I2C_GetFlagStatus(I2C2, I2C_FLAG_STOPF) == RESET) {}
@@ -156,6 +157,8 @@ uint8_t readRegI2C2(I2CReg r) {
 }
 
 uint32_t writeRegI2C2(I2CReg r, uint8_t data) {
+  // TODO: Add timeout conditions for all while loops
+
   // Wait if I2C2 is busy
   while (I2C2->ISR & I2C_ISR_BUSY) {}
 

--- a/fw/preamp/src/i2c.h
+++ b/fw/preamp/src/i2c.h
@@ -33,6 +33,7 @@ typedef struct {
 
 void initI2C1(uint8_t addr);
 void initI2C2();
+void deinitI2C2();
 
 uint8_t  readRegI2C2(I2CReg r);
 uint32_t writeRegI2C2(I2CReg r, uint8_t data);

--- a/fw/preamp/src/i2c.h
+++ b/fw/preamp/src/i2c.h
@@ -35,6 +35,7 @@ void initI2C1(uint8_t addr);
 void initI2C2();
 void deinitI2C2();
 
+uint32_t writeByteI2C2(I2CDev dev, uint8_t val);
 uint8_t  readRegI2C2(I2CReg r);
 uint32_t writeRegI2C2(I2CReg r, uint8_t data);
 

--- a/fw/preamp/src/int_i2c.c
+++ b/fw/preamp/src/int_i2c.c
@@ -96,6 +96,7 @@ void quiesceI2C() {
   // Ensure the I2C peripheral is disabled and pins are set as GPIO
   // Pins will be configured to HI-Z (pulled up externally)
   deinitI2C2();
+  configI2C2PinsAsGPIO();
 
   const uint32_t NUM_CONSECUTIVE_ONES = 9;
   // Require NUM_CONSECUTIVE_ONES on I2C's SDA before proceeding.
@@ -125,6 +126,7 @@ void quiesceI2C() {
 
   // Initialize the STM32's I2C2 bus as a master and control pins by peripheral
   initI2C2();
+  configI2C2Pins();
 }
 
 void initInternalI2C() {

--- a/fw/preamp/src/main.c
+++ b/fw/preamp/src/main.c
@@ -43,7 +43,7 @@ int main(void) {
   initAudio();    // Initialize audio mux, volumes, mute and standby
   initUart1();    // The preamp will receive its I2C network address via UART
   initUart2(9600);
-  initInternalI2C();  // Setup the internal I2C bus - worst case ~2.2 ms
+  initInternalI2C();  // Setup the internal I2C bus - worst case ~2.4 ms
 
   // RELEASE EXPANSION RESET
   // Needs to be high so the subsequent preamp board is not held in 'Reset Mode'

--- a/fw/preamp/src/main.c
+++ b/fw/preamp/src/main.c
@@ -43,7 +43,7 @@ int main(void) {
   initAudio();    // Initialize audio mux, volumes, mute and standby
   initUart1();    // The preamp will receive its I2C network address via UART
   initUart2(9600);
-  initInternalI2C();  // Setup the internal I2C bus
+  initInternalI2C();  // Setup the internal I2C bus - worst case ~2.2 ms
 
   // RELEASE EXPANSION RESET
   // Needs to be high so the subsequent preamp board is not held in 'Reset Mode'

--- a/fw/preamp/src/pins.c
+++ b/fw/preamp/src/pins.c
@@ -253,7 +253,7 @@ void writePin(Pin pp, bool set) {
 
 bool readPin(Pin pp) {
   GPIO_TypeDef* port = getPort(pp);
-  if (port->ODR & (1 << pp.pin)) {
+  if (port->IDR & (1 << pp.pin)) {
     return true;
   } else {
     return false;

--- a/fw/preamp/src/pins.c
+++ b/fw/preamp/src/pins.c
@@ -168,7 +168,8 @@ void initPins() {
 
   // Configure special function pins
   configUARTPins();
-  configI2CPins();
+  configI2C1Pins();
+  configI2C2PinsAsGPIO();
 }
 
 void configUARTPins() {
@@ -190,17 +191,14 @@ void configUARTPins() {
   GPIO_Init(getPort(uart1_tx_), &uartInit);
 }
 
-void configI2CPins() {
+void configI2C1Pins() {
   // Connect pins to alternate function for I2C1 and I2C2
   GPIO_PinAFConfig(getPort(i2c1_scl_), i2c1_scl_.pin, GPIO_AF_1);
   GPIO_PinAFConfig(getPort(i2c1_sda_), i2c1_sda_.pin, GPIO_AF_1);
-  GPIO_PinAFConfig(getPort(i2c2_scl_), i2c2_scl_.pin, GPIO_AF_1);
-  GPIO_PinAFConfig(getPort(i2c2_sda_), i2c2_sda_.pin, GPIO_AF_1);
 
   // Config I2C GPIO pins
   GPIO_InitTypeDef GPIO_InitStructureI2C = {
-      .GPIO_Pin = (1 << i2c1_scl_.pin) | (1 << i2c1_sda_.pin) |
-                  (1 << i2c2_scl_.pin) | (1 << i2c2_sda_.pin),
+      .GPIO_Pin   = (1 << i2c1_scl_.pin) | (1 << i2c1_sda_.pin),
       .GPIO_Mode  = GPIO_Mode_AF,
       .GPIO_Speed = GPIO_Speed_2MHz,
       .GPIO_OType = GPIO_OType_OD,
@@ -209,7 +207,27 @@ void configI2CPins() {
   GPIO_Init(getPort(i2c1_scl_), &GPIO_InitStructureI2C);
 }
 
+void configI2C2Pins() {
+  // Connect pins to alternate function for I2C1 and I2C2
+  GPIO_PinAFConfig(getPort(i2c2_scl_), i2c2_scl_.pin, GPIO_AF_1);
+  GPIO_PinAFConfig(getPort(i2c2_sda_), i2c2_sda_.pin, GPIO_AF_1);
+
+  // Config I2C GPIO pins
+  GPIO_InitTypeDef GPIO_InitStructureI2C = {
+      .GPIO_Pin   = (1 << i2c2_scl_.pin) | (1 << i2c2_sda_.pin),
+      .GPIO_Mode  = GPIO_Mode_AF,
+      .GPIO_Speed = GPIO_Speed_2MHz,
+      .GPIO_OType = GPIO_OType_OD,
+      .GPIO_PuPd  = GPIO_PuPd_NOPULL,
+  };
+  GPIO_Init(getPort(i2c2_scl_), &GPIO_InitStructureI2C);
+}
+
 void configI2C2PinsAsGPIO() {
+  // Default pins High-Z
+  writePin(i2c2_scl_, true);
+  writePin(i2c2_sda_, true);
+
   // Config I2C2 GPIO pins
   GPIO_InitTypeDef GPIO_InitStructureI2C = {
       .GPIO_Pin   = (1 << i2c2_scl_.pin) | (1 << i2c2_sda_.pin),
@@ -218,7 +236,7 @@ void configI2C2PinsAsGPIO() {
       .GPIO_OType = GPIO_OType_OD,
       .GPIO_PuPd  = GPIO_PuPd_NOPULL,
   };
-  GPIO_Init(GPIOB, &GPIO_InitStructureI2C);
+  GPIO_Init(getPort(i2c2_scl_), &GPIO_InitStructureI2C);
 }
 
 void writePin(Pin pp, bool set) {

--- a/fw/preamp/src/pins.h
+++ b/fw/preamp/src/pins.h
@@ -43,7 +43,8 @@ extern const Pin i2c2_sda_;             // Internal I2C bus SDA
 // Pin configuration
 void initPins();
 void configUARTPins();
-void configI2CPins();
+void configI2C1Pins();
+void configI2C2Pins();
 void configI2C2PinsAsGPIO();
 
 void writePin(Pin pp, bool set);

--- a/fw/preamp/test_reset.bash
+++ b/fw/preamp/test_reset.bash
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# By default just reset and verify I2C communication
+# If any argument is passed, also read special I2C debugging registers.
+read_i2c=false
+if (( $# > 0 )); then
+  read_i2c=true
+fi
+
+cnt=0
+failed=false
+
+exit_func () {
+  echo "Number of resets: $cnt"
+  exit 1
+}
+
+trap exit_func INT TERM
+
+# cd to preamp.py's directory
+cd "$(dirname ${BASH_SOURCE[0]})/../../hw/tests"
+
+max_time="0"
+while ! $failed; do
+  ((cnt=cnt+1))
+
+  # Reset preamp
+  if ! ./preamp.py -raq 2>/dev/null; then
+    echo "Error communicating to preamp"
+    break
+  fi
+
+  if $read_i2c; then
+    # Check if exp_nrst or exp_boot0 were set (used as error flags)
+    reg_tries=$(i2cget -y 1 0x08 0x17)
+    reg_itime=$(i2cget -y 1 0x08 0x18)
+    reg_err=$(i2cget -y 1 0x08 0x19)
+    printf "Reset $cnt, %u I2C init tries totalling %u us" "$reg_tries" "$reg_itime"
+    if (( $reg_err > 0 )); then
+      echo ", SDA ERROR";
+      failed=true
+    else
+      echo ""
+    fi
+
+    # Print stats every 100th time
+    if (( $reg_itime > $max_time )); then
+      max_time=$reg_itime
+    fi
+    if (( $cnt % 10 == 0 )); then
+      printf "Max init time so far: %u us\n" "$max_time"
+    fi
+  else
+    echo "Reset $cnt"
+  fi
+done
+echo "Number of reset attempts: $cnt"

--- a/fw/preamp/test_reset.bash
+++ b/fw/preamp/test_reset.bash
@@ -25,10 +25,12 @@ while ! $failed; do
   ((cnt=cnt+1))
 
   # Reset preamp
+  sleep 0.1
   if ! ./preamp.py -raq 2>/dev/null; then
     echo "Error communicating to preamp"
     break
   fi
+  sleep 0.1
 
   if $read_i2c; then
     # Check if exp_nrst or exp_boot0 were set (used as error flags)

--- a/fw/preamp_i2c_regs.md
+++ b/fw/preamp_i2c_regs.md
@@ -68,16 +68,16 @@
     </tr>
     <tr>
       <td>0x04</td>
-      <td>STANDBY</td>
+      <td>AMP ENABLE</td>
       <td align=center>-</td>
       <td align=center>-</td>
-      <td align=center>-</td>
-      <td align=center>-</td>
-      <td align=center>-</td>
-      <td align=center>-</td>
-      <td align=center>-</td>
-      <td align=center>STANDBY</td>
-      <td>0x00</td>
+      <td align=center>Z6EN</td>
+      <td align=center>Z5EN</td>
+      <td align=center>Z4EN</td>
+      <td align=center>Z3EN</td>
+      <td align=center>Z2EN</td>
+      <td align=center>Z1EN</td>
+      <td>0x3F</td>
     </tr>
     <tr>
       <td>0x05</td>
@@ -300,16 +300,21 @@ Mute each zone independently. Each bit ZxM can have the following values:
 | 0     | Not Muted   |
 | 1     | Muted       |
 
-### STANDBY
+### AMP ENABLE
 
 Read/write.
-Set bit 0 to standby all zones. Read to determine standby status.
-All amplifiers will be in standby at once, or all enabled.
+Bits 0 to 5 enable/disable the amplifier for a zone. A disabled amplifier will
+always remain muted, and won't be considered on for determining if all the
+amplifiers can be placed into standby. By default all amplifiers are enabled,
+but disabling an amplifier can be useful if only the preout is used for a zone.
 
-| Value | Description |
-| ----- | ----------- |
-| 0     | Enabled     |
-| 1     | In Standby  |
+| Value | Description       |
+| ----- | ----------------- |
+| 0     | Zone amp disabled |
+| 1     | Zone amp enabled  |
+
+Replaces STANDBY register. Old software will simply enable all zone amplifiers
+instead of disabling standby.
 
 ### ZONE[1:6]_VOL
 

--- a/fw/preamp_i2c_regs.md
+++ b/fw/preamp_i2c_regs.md
@@ -68,7 +68,7 @@
     </tr>
     <tr>
       <td>0x04</td>
-      <td>AMP ENABLE</td>
+      <td>AMP_ENABLE</td>
       <td align=center>-</td>
       <td align=center>-</td>
       <td align=center>Z6EN</td>
@@ -300,11 +300,11 @@ Mute each zone independently. Each bit ZxM can have the following values:
 | 0     | Not Muted   |
 | 1     | Muted       |
 
-### AMP ENABLE
+### AMP_ENABLE
 
 Read/write.
 Bits 0 to 5 enable/disable the amplifier for a zone. A disabled amplifier will
-always remain muted, and won't be considered on for determining if all the
+not be considered on for determining if all the
 amplifiers can be placed into standby. By default all amplifiers are enabled,
 but disabling an amplifier can be useful if only the preout is used for a zone.
 

--- a/hw/tests/preamp.py
+++ b/hw/tests/preamp.py
@@ -183,9 +183,11 @@ if args.unit > 1 and args.bootload:
   print("Bootloading expansion units is a work in progress...")
 
 # Print status if not entering bootloader mode
+error = 0
 if not args.bootload:
   if len(preamps.preamps) < args.unit:
-    print('Error: desired unit does not exist')
+    print('Error: desired unit does not exist', file=sys.stderr)
+    error = 1
   else:
     for u in range(len(preamps.preamps)):
       preamps.force_fans(preamp = u + 1, force = args.force_fans)
@@ -200,12 +202,14 @@ if not args.bootload:
 
 if args.self_test:
   if not self_check(preamps):
-    sys.exit(2)
+    error = 2
 if args.heat:
   if not heat_test(preamps, args.heat):
-    sys.exit(2)
+    error = 3
 
 if args.wait:
   input("Press Enter to continue...")
+
+sys.exit(error)
 
 # TODO? 'STANDBY' : 0x04


### PR DESCRIPTION
If the preamp's micro is reset in the middle of sending an I2C message, the bus is left in a bad state with the addressed slave expecting the rest of the message. The old method that attempted to fix this was rough and only partially fixed the problem. Now, At every startup the micro will send clock pulses on SCL until enough 1's are read on the SDA line to consider the bus inactive.  The old method failed to initialize the bus once every ~150 times, the new method has successfully initialized the bus hundreds of thousands of times in a row with no errors.

This PR also currently includes two other minor changes:
- Initialize the ADC's Setup Byte. Previously the reset value of the ADC's Setup Byte was being relied on. But if the ADC receives a write of all ones (as is the case if the ADC was addressed in write mode, then the micro resets, then 9 clocks are sent with SDA high) then the Setup Byte is written to all ones. This switches the reference from VDD (3.3V) to a 2.048V internal reference so all the temps and voltages start reading as much higher than they really are.
- Since STANDBY is now handled by logic in firmware, slightly modify the STANDBY register to act as an AMP_DISABLE register. It will default to 0x3F, but if any of the lower 6 bits are written low the corresponding zone amp will be disabled. A disabled amp means it won't count as on when determining standby. This could be useful to save power if preout-only zones are used. I haven't added any software support for this setting yet. If old software communicates to this register thinking it's still the standby register, it will write zeros expecting to enter standby but the new firmware will disable the amps, which achieves the same result. So this change is backwards-compatible.