### PR TITLE
Improved firmware programming

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
           "console": "integratedTerminal",
           "cwd": "${workspaceFolder}",
           "module": "amplipi.hw",
-          "args": ["-n 2", "--flash", "/home/pi/amplipi-test/fw/preamp/build/preamp_bd.bin"],
+          "args": ["--flash", "fw/preamp/build/preamp_bd.bin"],
           "justMyCode": false
       }
   ]

--- a/amplipi/hw.py
+++ b/amplipi/hw.py
@@ -323,11 +323,14 @@ class Preamps:
     present = preamp.available()
     print(f"{self.unit_num_to_name(unit)}'s old firmware version: {preamp.read_version() if present else 'unknown'}")
 
+    # For now the firmware can only pass through 9600 baud to expanders
+    baud = 9600 if unit > 0 else baud
+
     # Reset into bootloader mode and check if bootloader can be communicated to
     self.reset(unit = unit, bootloader = True)
     if not present:
       present = subprocess.run([f'stm32flash -b {baud} {PI_SERIAL_PORT}'],
-                                shell=True, check=False).returncode == 0
+                                shell=True, check=False, stdout=subprocess.DEVNULL).returncode == 0
     if not present:
       # Unit not found, give up
       # TODO: retry?
@@ -340,8 +343,6 @@ class Preamps:
       print(f"Setting {self.unit_num_to_name(p)}'s UART as passthrough")
       self.preamps[p].uart_passthrough(True)
 
-    # For now the firmware can only pass through 9600 baud to expanders
-    baud = 9600 if unit > 0 else baud
     code = subprocess.run([f'stm32flash -vb {baud} -w {filepath} {PI_SERIAL_PORT}'],
                               shell=True, check=False).returncode
     if code != 0:

--- a/amplipi/hw.py
+++ b/amplipi/hw.py
@@ -24,7 +24,7 @@ from enum import Enum
 import subprocess
 import sys
 import time
-from typing import List
+from typing import List, Union
 
 # Third-party imports
 from serial import Serial
@@ -37,8 +37,8 @@ from amplipi import utils
 if utils.is_amplipi():
   from RPi import GPIO
 
-
 PI_SERIAL_PORT = '/dev/serial0'
+
 
 class FwVersion:
   """ Represents the Preamp Board's firmware version """
@@ -63,6 +63,7 @@ class FwVersion:
 
   def __repr__(self):
     return f'FwVersion({self.major}, {self.minor}, {self.git_hash:07X}, {self.dirty})'
+
 
 class Preamp:
   """ Low level discovery and communication for the AmpliPi Preamp's firmware """
@@ -291,7 +292,7 @@ class Preamps:
       return False
 
 
-  def enumerate(self) -> None:
+  def enumerate(self, debug: bool = False) -> None:
     """ Re-enumerate preamp connections """
     self.preamps = []
     for i in range(self.MAX_UNITS):
@@ -299,47 +300,108 @@ class Preamps:
       if not p.available():
         break
       self.preamps.append(p)
-    print(f'Found {len(self.preamps)} preamp(s)')
+    if debug:
+      print(f'Found {len(self.preamps)} preamp(s)')
 
-  def flash(self, filepath: str, num_units: int, baud: int = 115200) -> bool:
-    """ Flash all available preamps with a given file """
+  def program(self, filepath: str, unit: int = 0, baud: int = 115200) -> bool:
+    """ Attempt to program a single AmpliPi unit
+
+        This function assumes any previous units exist,
+        but does not assume the requested unit exists.
+        If it does not exist then this function will return False.
+    """
+
+    # If the unit is running print its current version info
+    preamp = Preamp(unit, self._bus)
+    present = preamp.available()
+    print(f"Unit {unit}'s old firmware version: {preamp.read_version() if present else 'unknown'}")
+
+    # Reset into bootloader mode and check if bootloader can be communicated to
+    self.reset(unit = unit, bootloader = True)
+    if not present:
+      present = subprocess.run([f'stm32flash -b {baud} {PI_SERIAL_PORT}'],
+                                shell=True, check=False).returncode == 0
+    if not present:
+      # Unit not found, give up
+      # TODO: retry?
+      print(f"Couldn't communicate with unit {unit}'s bootloader, stopping programming")
+      return False
+
+    # Set UART passthrough on any previous units
+    for p in range(unit):
+      print(f"Setting unit {p}'s UART as passthrough")
+      self.preamps[p].uart_passthrough(True)
+
+    # For now the firmware can only pass through 9600 baud to expanders
+    baud = 9600 if unit > 0 else baud
+    code = subprocess.run([f'stm32flash -vb {baud} -w {filepath} {PI_SERIAL_PORT}'],
+                              shell=True, check=False).returncode
+    if code != 0:
+      # TODO: Error handling
+      print(f'Error programming unit {unit}, stopping programming')
+
+    # Successfully programmed unit, reset to exit bootloader
+    self.reset()
+
+    # Verify newly programmed unit communicates
+    if preamp.available():
+      print(f"Unit {unit}'s new firmware version: {preamp.read_version()}")
+    else:
+      # Can't communicate to unit, give up
+      # TODO: retry?
+      print(f"Couldn't communicate to unit {unit} after programming, stopping programming")
+      return False
+
+    # Programming succeeded!
+    return True
+
+  def program_all(self, filepath: str, num_units: Union[None, int], baud: int = 115200) -> bool:
+    """ Program all available preamps with a given file
+        If num_units is not None, programming will stop after num_units
+    """
 
     if baud not in self.BAUD_RATES:
       raise ValueError(f'Baud rate must be one of {self.BAUD_RATES}')
 
-    for unit in range(num_units):
-      # If the unit was previously able to be communicated to,
-      # read the version and print it.
-      ver_str = ''
-      if unit < len(self.preamps):
-        fw_ver = self.preamps[unit].read_version()
-        ver_str = f'(version {fw_ver}) '
-      print(f"Resetting unit {unit}'s preamp {ver_str}and starting execution in bootloader ROM")
-      self.reset(unit = unit, bootloader = True)
-      for p in range(unit): # Set UART passthrough on any previous units
-        print(f'Setting unit {p} as passthrough')
-        self.preamps[p].uart_passthrough(True)
-      if unit > 0: # For now the firmware can only pass through 9600 buad to expanders
-        baud = 9600
-      flash_result = subprocess.run([f'stm32flash -vb {baud} -w {filepath} {PI_SERIAL_PORT}'], shell=True, check=False)
-      success = flash_result.returncode == 0
-      if not success:
-        # TODO: Error handling
-        print(f'Error flashing unit {unit}, stopping programming')
-      print('Resetting all preamps and starting execution in user flash')
-      self.reset()
+    # Force attempting to program at least 1 unit
+    if num_units is not None and num_units <= 0:
+      num_units = 1
+    previous_unit_count = len(self)
+    program_count = self.MAX_UNITS if num_units is None else num_units
+    print(f'Programming up to {program_count} AmpliPi Preamps '
+          f'({previous_unit_count} currently detected)')
+    if previous_unit_count <= 0:
+      previous_unit_count = 1
 
-      # If the programming was successful it was just added to the list of preamps
-      if unit < len(self.preamps):
-        fw_ver = self.preamps[unit].read_version()
-        print(f"Unit {unit}'s new version: {fw_ver}")
-      elif success:
-        success = False
-        print(f"Can't communicate with unit {unit}, stopping programming")
+    # Attempt programming until program_count, but stop if an error occurs
+    unit = 0
+    success = True
+    while success and unit < program_count:
+      print()
+      success = self.program(filepath, unit)
+      if success:
+        unit += 1
 
-      if not success:
-        break
-    return success
+    # Success considerations:
+    #   1. If a failure occured during programming: failure
+    #   2. If num_units were programmed: success
+    #   3. Programmed units is >= the number of previous units that enumerated.
+    #      It is possible, but unlikely, that some units didn't work before
+    #      and didn't get fixed with the program.
+    success_str = f'{unit} AmpliPi preamp'
+    if unit == 0:
+      success_str += 's'
+      fail_str = success_str
+    elif unit == 1:
+      fail_str = success_str
+    elif unit > 1:
+      success_str += 's'
+      fail_str = 'only ' + success_str
+    if unit == program_count or unit >= previous_unit_count:
+      print(f'\nSuccessfully programmed {success_str}.')
+      return True
+    print(f'\nFailed programming, {fail_str} programmed.')
+    return False
 
 
 #class PeakDetect:
@@ -359,24 +421,15 @@ if __name__ == '__main__':
                       help='print preamp firmware version(s)')
   parser.add_argument('-l', '--log', metavar='LEVEL', default='WARNING',
                       help='set logging level as DEBUG, INFO, WARNING, ERROR, or CRITICAL')
-  parser.add_argument('-n', '--num-units', metavar='N', type=int,
+  parser.add_argument('-n', '--num-units', metavar='N', type=int, choices=range(1,7),
                       help='set the number of preamps instead of auto-detecting')
   args = parser.parse_args()
 
   preamps = Preamps(args.reset)
 
   if args.flash is not None:
-    # Default to attempting to flash all units found.
-    num_units = len(preamps)
-    if args.num_units is not None:
-      # Override auto-detected preamp count
-      num_units = args.num_units
-    if num_units <= 0:
-      # Always try to flash at least 1 unit
-      num_units = 1
-    if not preamps.flash(filepath = args.flash, num_units = num_units, baud = args.baud):
+    if not preamps.program_all(filepath = args.flash, num_units = args.num_units, baud = args.baud):
       sys.exit(2)
-
 
   if len(preamps) == 0:
     print('No preamps found, exiting')


### PR DESCRIPTION
Previously firmware programming, by default, attempted to program the number of units that were able to be communicated with before programming. This method is flawed if any of the preamps are in a broken or completely unprogrammed state. So the new method implemented here always attempts to program one more unit until a unit fails to program. That way newly plugged-in units or previously unprogrammed ones are always at least attempted to be programmed.