### PR TITLE
Reduce popping that occurs on volume change

### DIFF
--- a/amplipi/rt.py
+++ b/amplipi/rt.py
@@ -450,7 +450,7 @@ class _Preamps:
     preamp = (int(zone / 6) + 1) * 8
     zone = zone % 6
     regs = self.preamps[preamp]
-    src_types = self.preamps[0x08][_REG_ADDRS['SRC_AD']]
+    src_types = regs[_REG_ADDRS['SRC_AD']]
     src = ((regs[_REG_ADDRS['ZONE456_SRC']] << 8) | regs[_REG_ADDRS['ZONE123_SRC']] >> 2 * zone) & 0b11
     src_type = _SRC_TYPES.get((src_types >> src) & 0b01)
     vol = -regs[_REG_ADDRS['VOL_ZONE1'] + zone]

--- a/fw/preamp/src/audio.c
+++ b/fw/preamp/src/audio.c
@@ -50,11 +50,11 @@ const I2CReg zone_right_[NUM_ZONES] = {
 
 // Zone volumes, range is [-80, 0] dB with 0 as the max (no attenuation).
 // Requested volume for each zone, default to  mute (-90 dB)
-uint8_t vol_req_[NUM_ZONES] = {VOL_MUTE};
+uint8_t vol_req_[NUM_ZONES];
 
 // Actual volume (last written via I2C)
 // The TDA7448 volume controller always reports 0x00 on read
-uint8_t vol_[NUM_ZONES] = {0};
+uint8_t vol_[NUM_ZONES] = {};
 
 // If any zone uses only the preout, the amp can be 'disabled' which will
 // remove it from consideration for leaving standby.
@@ -229,6 +229,7 @@ void initAudio() {
     enZoneAmp(zone, true);
     mute(zone, true);
     setZoneSource(zone, DEFAULT_SOURCE);
+    vol_req_[zone] = VOL_MUTE;
   }
 
   /* Initialize each source's analog/digital mux to select digital.


### PR DESCRIPTION
A "popping" sound can occur for some audio when changing the volume. This seems to be a property of the volume controller since the noise occur on a volume change even if nothing else in the system changes. The worst-case seems to be a sine-wave and looking at the signal on an oscilloscope the signal is definitely getting disrupted during a volume write. However, the larger the volume change the larger the disruption seems to be. The corollary to that is that only changing the volume 1 dB at a time should produce the least "popping", which seems to hold true and is implemented here.

The strategy here is to hold the "desired value" and every millisecond increment or decrement the actual volume until it hits the desired value.

Also fixed a bug where only the first zone was properly getting set to the lowest volume at startup.