### PR TITLE
Add list of supported commands to source info

### DIFF
--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -117,6 +117,7 @@ class SourceInfo(BaseModel):
   album: Optional[str]
   station: Optional[str] # name of radio station
   img_url: Optional[str]
+  supported_cmds: List[str] = []
 
 class Source(Base):
   """ An audio source """

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -234,6 +234,7 @@ def test_get_source(client, sid):
   s = find(base_config()['sources'], sid)
   assert s is not None
   assert s['name'] == jrv['name']
+  assert jrv['info']['supported_cmds'] is not None
 
 @pytest.mark.parametrize('sid', base_source_ids())
 def test_patch_source(client, sid):

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -271,33 +271,19 @@ function updateSourceView(status) {
     cover.src = src.info.img_url ? src.info.img_url : icons['none'];
     const playing = src.info.state == "playing";
     playing_indicator.style.visibility = playing ? "visible" : "hidden";
-    if (stream_id) {
-      // find the right stream
-      let stream = undefined;
-      for (const s of status.streams) {
-        if (s.id == stream_id) {
-          stream = s;
-          break;
-        }
-      }
-      if (stream) {
-        // update the player's song info
-        if (stream.type == 'pandora') {
-          next.style.visibility = "visible";
-          like.style.visibility = "visible";
-          dislike.style.visibility = "visible";
-          play_pause.style.visibility = "visible";
-          play_pause.classList.toggle('fa-play', !playing);
-          play_pause.classList.toggle('fa-pause', playing);
-        } else if (stream.type == 'spotify') {
-          next.style.visibility = "visible";
-          prev.style.display = "inline-block";
-          play_pause.style.visibility = "visible";
-          play_pause.classList.toggle('fa-play', !playing);
-          play_pause.classList.toggle('fa-pause', playing);
-        }
-      }
+
+    // update the control buttons
+    supported_cmds = src.info.supported_cmds;
+    next.style.visibility = supported_cmds.includes("next") ? "visible" : "hidden";
+    like.style.visibility = supported_cmds.includes("love") ? "visible" : "hidden";
+    dislike.style.visibility = supported_cmds.includes("ban") ? "visible" : "hidden";
+    prev.style.display = supported_cmds.includes("prev") ? "inline-block" : "none";
+    if (supported_cmds.includes("pause")) {
+      play_pause.style.visibility = "visible";
+      play_pause.classList.toggle('fa-play', !playing);
+      play_pause.classList.toggle('fa-pause', playing);
     }
+
     // update each source's input
     player = $("#s" + src.id + "-player")[0];
     player.dataset.srcInput = src.input;

--- a/web/templates/index.html.j2
+++ b/web/templates/index.html.j2
@@ -83,11 +83,11 @@
                 <h6 class="song">{{ info['track'] }}</h6>
               </div>
               <div class="controls">
-                <i class="step-backward fas fa-backward" onclick="onPrev(this)"></i>
-                <i class="play-pause fas fa-play" onclick="onPlayPause(this)"></i>
-                <i class="step-forward fas fa-forward" onclick="onNext(this)"></i>
-                <i class="like fas fa-heart" onclick="onLike(this)"></i>
-                <i class="dislike fas fa-thumbs-down" onclick="onDislike(this)"></i>
+                <i class="step-backward fas fa-backward" onclick="onPrev(this)"       style="display: {% if 'prev' in src['info']['supported_cmds'] %} inline-block; {% else %} none; {% endif %}"></i>
+                <i class="play-pause fas fa-pause"       onclick="onPlayPause(this)"  style="visibility: {% if 'pause' in src['info']['supported_cmds'] %} visible; {% else %} hidden; {% endif %}"></i>
+                <i class="step-forward fas fa-forward"   onclick="onNext(this)"       style="visibility: {% if 'next' in src['info']['supported_cmds'] %} visible; {% else %} hidden; {% endif %}"></i>
+                <i class="like fas fa-heart"             onclick="onLike(this)"       style="visibility: {% if 'love' in src['info']['supported_cmds'] %} visible; {% else %} hidden; {% endif %}"></i>
+                <i class="dislike fas fa-thumbs-down"    onclick="onDislike(this)"    style="visibility: {% if 'ban' in src['info']['supported_cmds'] %} visible; {% else %} hidden; {% endif %}"></i>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This should make it easy to discover different commands supported by different stream interfaces. At the moment only pandora and spotify are supported.

Needs more testing. @klay2000 can you test this out?