### PR TITLE
Make password generation optional when deploying

### DIFF
--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -671,7 +671,7 @@ def add_tests(env, progress) -> List[Task]:
   return tasks
 
 def install(os_deps=True, python_deps=True, web=True, restart_updater=False,
-            display=True, firmware=True, progress=print_task_results) -> bool:
+            display=True, firmware=True, password=True, progress=print_task_results) -> bool:
   """ Install and configure AmpliPi's dependencies """
   # pylint: disable=too-many-return-statements
   tasks = [Task('setup')]
@@ -700,7 +700,6 @@ def install(os_deps=True, python_deps=True, web=True, restart_updater=False,
     if failed():
       print('OS dependency install step failed, exiting...')
       return False
-  tasks += _check_password(env, progress)
   if python_deps:
     with open(os.path.join(env['base_dir'], 'requirements.txt')) as req:
       deps = req.read().splitlines()
@@ -730,6 +729,10 @@ def install(os_deps=True, python_deps=True, web=True, restart_updater=False,
     tasks += _update_firmware(env, progress)
     if failed():
       return False
+  if password:
+    tasks += _check_password(env, progress)
+    if failed():
+      return False
   if web and not restart_updater:
     # let the user know how to handle a specific failure condition of the old updater
     UPDATER_MSG = """!!! OLDER UPDATERS CAN MISTAKENLY FAIL AFTER THIS !!!
@@ -755,6 +758,8 @@ if __name__ == '__main__':
     help="Install and run the front-panel display service")
   parser.add_argument('--firmware', action='store_true', default=False,
     help="Flash the latest firmware")
+  parser.add_argument('--password', action='store_true', default=False,
+    help="Generate and set a new default password for the pi user.")
   flags = parser.parse_args()
   print('Configuring AmpliPi installation')
   has_args = flags.python_deps or flags.os_deps or flags.web or flags.restart_updater or flags.display or flags.firmware
@@ -763,4 +768,5 @@ if __name__ == '__main__':
   if sys.version_info.major < 3 or sys.version_info.minor < 7:
     print('  WARNING: minimum python version is 3.7')
   install(os_deps=flags.os_deps, python_deps=flags.python_deps, web=flags.web,
-          display=flags.display, firmware=flags.firmware, restart_updater=flags.restart_updater)
+          display=flags.display, firmware=flags.firmware, password=flags.password,
+          restart_updater=flags.restart_updater)

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -10,14 +10,20 @@ HELP="Install/Update AmpliPi software on a remote system defined by USER@HOST (d
   usage: deploy [USER@HOST] [--mock-ctrl]\n
 \n
   --dev: add info to version showing the current git hash and branch\n
+  --fw:  program the latest preamp firmware\n
+  --pw:  generate and set a new random password\n
 "
 
 user_host='pi@amplipi.local'
 user_host_set=false
 dev=false
+fw=false
+pw=false
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --dev) dev=true ;;
+    --fw) fw=true ;;
+    --pw) pw=true ;;
     -h|--help) echo -e $HELP; exit 0 ;;
     *) if ! $user_host_set; then
           user_host=$1
@@ -32,8 +38,18 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
-read -p "Deploying amplipi project (development build) to $user_host, press any key to continue (Ctrl-C to quit)" -n 1
-echo "" # newline
+printf "Deploying amplipi project "
+$dev && printf "(development build) "
+printf "to $user_host.\n"
+printf "Preamp firmware will "
+$fw || printf "NOT "
+printf "be programmed.\n"
+printf "A new password will "
+$pw || printf "NOT "
+printf "be generated.\n"
+#to $user_host
+read -p "Press any key to continue (Ctrl-C to quit)" -n 1
+printf "\n"
 # TODO: deploy amplipi as a python installed package with pip or something similar
 # NOTE: this probably doesnt make sense until we use a more advanced version of poetry or figure out how to not spam the global directory with our scripts and other files?
 # check if amplipi is found
@@ -142,4 +158,7 @@ echo "Extracting folder into $user_host:~/amplipi-dev"
 ssh $user_host "cd amplipi-dev && tar -xvf ../${release_name}.tar.gz && cp -af ${release_name}/* . && rm -r ${release_name}"
 echo "Configuring installation"
 ssh $user_host "chmod +x amplipi-dev/scripts/configure.py"
-ssh $user_host -t "python3 amplipi-dev/scripts/configure.py --os-deps --python-deps --web --restart-updater --display"
+opts=""
+$fw && opts="$opts --firmware"
+$pw && opts="$opts --password"
+ssh $user_host -t "python3 amplipi-dev/scripts/configure.py --os-deps --python-deps --web --restart-updater --display$opts"


### PR DESCRIPTION
A default password will be generated and set when performing an update, if a default password doesn't exist at ~/.config/amplipi/default_password.txt

If Deploying or Configuring no password changes will be made unless a flag is specifically set.

Also programming the firmware wasn't an option when using the deploy script so I added that here along with the password flag.