### PR TITLE
Fix front-panel volume display

### DIFF
--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -728,8 +728,8 @@ def view(request: Request, ctrl: Api = Depends(get_ctrl), src: int = 0):
     'ungrouped_zones': [ungrouped_zones(ctrl, src.id) for src in state.sources if src.id is not None],
     'song_info': [src.info for src in state.sources if src.info is not None], # src.info should never be None
     'version': state.info.version if state.info else 'unknown',
-    'min_vol': models.MIN_VOL,
-    'max_vol': models.MAX_VOL,
+    'min_vol': models.MIN_VOL_F,
+    'max_vol': models.MAX_VOL_F,
   }
   return templates.TemplateResponse('index.html.j2', context, media_type='text/html')
 

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -108,12 +108,12 @@ class Api:
       {"id": 1000, "name": "Groove Salad", "type": "internetradio", "url": "http://ice6.somafm.com/groovesalad-32-aac", "logo": "https://somafm.com/img3/groovesalad-400.jpg"},
     ],
     "zones": [ # this is an array of zones, array length depends on # of boxes connected
-      {"id": 0, "name": "Zone 1", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
-      {"id": 1, "name": "Zone 2", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
-      {"id": 2, "name": "Zone 3", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
-      {"id": 3, "name": "Zone 4", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
-      {"id": 4, "name": "Zone 5", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
-      {"id": 5, "name": "Zone 6", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
+      {"id": 0, "name": "Zone 1", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL_F, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
+      {"id": 1, "name": "Zone 2", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL_F, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
+      {"id": 2, "name": "Zone 3", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL_F, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
+      {"id": 3, "name": "Zone 4", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL_F, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
+      {"id": 4, "name": "Zone 5", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL_F, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
+      {"id": 5, "name": "Zone 6", "source_id": 0, "mute": True, "disabled": False, "vol_f": models.MIN_VOL_F, "vol_min": models.MIN_VOL_DB, "vol_max": models.MAX_VOL_DB},
     ],
     "groups": [
     ],

--- a/amplipi/display/display.py
+++ b/amplipi/display/display.py
@@ -260,12 +260,11 @@ def draw_volume_bars(draw, font, small_font, zones: List[models.Zone], x=0, y=0,
   n = len(zones)
   if n == 0: # No zone info from AmpliPi server
     pass
-  elif n <= 6: # Draw horizonal bars
+  elif n <= 6: # Draw horizonal bars and full zone names
     wb = int(width / 2)                   # Each bar's full width
     hb = 12                               # Each bar's height
     sp = int((height - n*hb) / (2*(n-1))) # Spacing between bars
-    xb = width - wb
-    vol2pix = wb / -78
+    xb = width - wb                       # Bar starting (left) x coordinate
     for i in range(n):
       yb = y + i*hb + 2*i*sp # Bar starting y-position
 
@@ -273,20 +272,20 @@ def draw_volume_bars(draw, font, small_font, zones: List[models.Zone], x=0, y=0,
       draw.text((x, yb), zones[i].name, font=font, fill=Color.WHITE.value)
 
       # Draw background of volume bar
-      draw.rectangle(((xb, int(yb+2), xb+wb, int(yb+hb))), fill=Color.LIGHTGRAY.value)
+      draw.rectangle((xb, int(yb+2), xb+wb, int(yb+hb)), fill=Color.LIGHTGRAY.value)
 
       # Draw volume bar
-      if zones[i].vol > models.MIN_VOL:
+      if zones[i].vol_f > models.MIN_VOL:
         color = Color.DARKGRAY.value if zones[i].mute else Color.BLUE.value
-        xv = xb + (wb - round(zones[i].vol * vol2pix))
-        draw.rectangle(((xb, int(yb+2), xv, int(yb+hb))), fill=color)
-  elif n <= 18: # Draw vertical bars
+        xv = xb + round(zones[i].vol_f * wb)
+        draw.rectangle((xb, int(yb+2), xv, int(yb+hb)), fill=color)
+  else: # Draw vertical bars and zone number
     # Get the pixel height of a character, and add vertical margins
     ch = small_font.getbbox('0', anchor='lt')[3] + 4
     wb = 12                               # Each bar's width
+    hb = height - ch                      # Each bar's full height
     sp = int((width - n*wb) / (2*(n-1)))  # Spacing between bars
-    yt = y + height - ch                  # Text top y-position
-    vol2pix = (height - ch) / -78         # dB to pixels conversion factor
+    yb = y + hb                           # Bar starting (bottom) y coordinate
     for i in range(n):
       xb = x + i*wb + 2*i*sp # Bar starting x-position
 
@@ -295,15 +294,14 @@ def draw_volume_bars(draw, font, small_font, zones: List[models.Zone], x=0, y=0,
                 anchor='mm', font=small_font, fill=Color.WHITE.value)
 
       # Draw background of volume bar
-      draw.rectangle(((xb, y, xb+wb, yt)), fill=Color.LIGHTGRAY.value)
+      draw.rectangle((xb, yb, xb+wb, y), fill=Color.LIGHTGRAY.value)
 
       # Draw volume bar
-      if zones[i].vol > models.MIN_VOL:
+      if zones[i].vol_f > models.MIN_VOL:
         color = Color.DARKGRAY.value if zones[i].mute else Color.BLUE.value
-        yv = y + round(zones[i].vol * vol2pix)
-        draw.rectangle(((xb, yv, xb+wb, yt)), fill=color)
-  else:
-    log.error("Can't display more than 18 volumes")
+        yv = yb - round(zones[i].vol_f * hb)
+        draw.rectangle((xb, yb, xb+wb, yv), fill=color)
+  #TODO: For more than 18 zones, show on multiple screens.
 
 
 # Pins

--- a/amplipi/display/display.py
+++ b/amplipi/display/display.py
@@ -275,7 +275,7 @@ def draw_volume_bars(draw, font, small_font, zones: List[models.Zone], x=0, y=0,
       draw.rectangle((xb, int(yb+2), xb+wb, int(yb+hb)), fill=Color.LIGHTGRAY.value)
 
       # Draw volume bar
-      if zones[i].vol_f > models.MIN_VOL:
+      if zones[i].vol_f > models.MIN_VOL_F:
         color = Color.DARKGRAY.value if zones[i].mute else Color.BLUE.value
         xv = xb + round(zones[i].vol_f * wb)
         draw.rectangle((xb, int(yb+2), xv, int(yb+hb)), fill=color)
@@ -297,7 +297,7 @@ def draw_volume_bars(draw, font, small_font, zones: List[models.Zone], x=0, y=0,
       draw.rectangle((xb, yb, xb+wb, y), fill=Color.LIGHTGRAY.value)
 
       # Draw volume bar
-      if zones[i].vol_f > models.MIN_VOL:
+      if zones[i].vol_f > models.MIN_VOL_F:
         color = Color.DARKGRAY.value if zones[i].mute else Color.BLUE.value
         yv = yb - round(zones[i].vol_f * hb)
         draw.rectangle((xb, yb, xb+wb, yv), fill=color)

--- a/amplipi/extras.py
+++ b/amplipi/extras.py
@@ -22,7 +22,7 @@ Additional AmpliPi methods
 from amplipi import models
 from amplipi import utils
 
-def vol_string(vol, min_vol=models.MIN_VOL, max_vol=models.MAX_VOL):
+def vol_string(vol, min_vol=models.MIN_VOL_F, max_vol=models.MAX_VOL_F):
   """ Make a visual representation of a volume """
   vol_range = max_vol - min_vol + 1
   vol_str_len = 20

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -30,10 +30,10 @@ from pydantic import BaseSettings, BaseModel, Field
 # pylint: disable=too-few-public-methods
 # pylint: disable=missing-class-docstring
 
-MIN_VOL = 0.0
+MIN_VOL_F = 0.0
 """ Min volume for slider bar. Will be mapped to dB. """
 
-MAX_VOL = 1.0
+MAX_VOL_F = 1.0
 """ Max volume for slider bar. Will be mapped to dB. """
 
 MIN_VOL_DB = -80
@@ -47,7 +47,7 @@ MIN_DB_RANGE = 20
 
 def pcnt2Vol(pcnt: float) -> int:
   """ Convert a percent to volume in dB """
-  assert MIN_VOL <= pcnt <= MAX_VOL
+  assert MIN_VOL_F <= pcnt <= MAX_VOL_F
   return round(pcnt * (MAX_VOL_DB - MIN_VOL_DB) + MIN_VOL_DB)
 
 class fields(SimpleNamespace):
@@ -58,12 +58,12 @@ class fields(SimpleNamespace):
   ZoneId = Field(ge=0, le=35)
   Mute = Field(description='Set to true if output is muted')
   Volume = Field(ge=MIN_VOL_DB, le=MAX_VOL_DB, description='Output volume in dB')
-  VolumeF = Field(ge=MIN_VOL, le=MAX_VOL, description='Output volume as a floating-point number')
+  VolumeF = Field(ge=MIN_VOL_F, le=MAX_VOL_F, description='Output volume as a floating-point number')
   VolumeMin = Field(ge=MIN_VOL_DB, le=MAX_VOL_DB, description='Min output volume in dB')
   VolumeMax = Field(ge=MIN_VOL_DB, le=MAX_VOL_DB, description='Max output volume in dB')
   GroupMute = Field(description='Set to true if output is all zones muted')
   GroupVolume = Field(ge=MIN_VOL_DB, le=MAX_VOL_DB, description='Average output volume')
-  GroupVolumeF = Field(ge=MIN_VOL, le=MAX_VOL, description='Average output volume as a floating-point number')
+  GroupVolumeF = Field(ge=MIN_VOL_F, le=MAX_VOL_F, description='Average output volume as a floating-point number')
   Disabled = Field(description='Set to true if not connected to a speaker')
   Zones = Field(description='Set of zone ids belonging to a group')
   Groups = Field(description='List of group ids')
@@ -83,14 +83,14 @@ class fields_w_default(SimpleNamespace):
   SourceId = Field(default=0, ge=0, le=3, description='id of the connected source')
   Mute = Field(default=True, description='Set to true if output is muted')
   Volume = Field(default=MIN_VOL_DB, ge=MIN_VOL_DB, le=MAX_VOL_DB, description='Output volume in dB')
-  VolumeF = Field(default=MIN_VOL, ge=MIN_VOL, le=MAX_VOL, description='Output volume as a floating-point number')
+  VolumeF = Field(default=MIN_VOL_F, ge=MIN_VOL_F, le=MAX_VOL_F, description='Output volume as a floating-point number')
   VolumeMin = Field(default=MIN_VOL_DB, ge=MIN_VOL_DB, le=MAX_VOL_DB,
                     description='Min output volume in dB')
   VolumeMax = Field(default=MAX_VOL_DB, ge=MIN_VOL_DB, le=MAX_VOL_DB,
                     description='Max output volume in dB')
   GroupMute = Field(default=True, description='Set to true if output is all zones muted')
-  GroupVolume = Field(default=MIN_VOL, ge=MIN_VOL, le=MAX_VOL, description='Average output volume')
-  GroupVolumeF = Field(default=MIN_VOL, ge=MIN_VOL, le=MAX_VOL, description='Average output volume as a floating-point number')
+  GroupVolume = Field(default=MIN_VOL_F, ge=MIN_VOL_F, le=MAX_VOL_F, description='Average output volume')
+  GroupVolumeF = Field(default=MIN_VOL_F, ge=MIN_VOL_F, le=MAX_VOL_F, description='Average output volume as a floating-point number')
   Disabled = Field(default=False, description='Set to true if not connected to a speaker')
 
 class Base(BaseModel):
@@ -717,7 +717,7 @@ class Announcement(BaseModel):
   """
   media : str = Field(description="URL to media to play as the announcement")
   vol: Optional[int] = Field(default=None, ge=MIN_VOL_DB, le=MAX_VOL_DB, description='Output volume in dB, overrides vol_f')
-  vol_f: float = Field(default=0.5, ge=MIN_VOL, le=MAX_VOL, description="Output Volume (float)")
+  vol_f: float = Field(default=0.5, ge=MIN_VOL_F, le=MAX_VOL_F, description="Output Volume (float)")
   source_id: int = Field(default=3, ge=0, le=3, description='Source to announce with')
   zones: Optional[List[int]] = fields.Zones
   groups: Optional[List[int]] = fields.Groups

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -241,16 +241,16 @@ def vol_float_to_db(vol: float, db_min: int = models.MIN_VOL_DB, db_max: int = m
   # Alternatively a logarithmic function or power <1 could be used:
   # dB = log_{s+1}(s*x+1) where s is a scaling factor
   # dB = x^0.5
-  range_f = models.MAX_VOL - models.MIN_VOL
+  range_f = models.MAX_VOL_F - models.MIN_VOL_F
   range_db = db_max - db_min
-  vol_db = round((vol - models.MIN_VOL) * range_db / range_f + db_min)
+  vol_db = round((vol - models.MIN_VOL_F) * range_db / range_f + db_min)
   vol_db_clamped = clamp(vol_db, models.MIN_VOL_DB, models.MAX_VOL_DB)
   return vol_db_clamped
 
 def vol_db_to_float(vol: int, db_min: int = models.MIN_VOL_DB, db_max: int = models.MAX_VOL_DB) -> float:
   """ Convert volume in a dB range to floating-point """
-  range_f = models.MAX_VOL - models.MIN_VOL
+  range_f = models.MAX_VOL_F - models.MIN_VOL_F
   range_db = db_max - db_min
-  vol_f = (vol - db_min) * range_f / range_db + models.MIN_VOL
-  vol_f_clamped = clamp(vol_f, models.MIN_VOL, models.MAX_VOL)
+  vol_f = (vol - db_min) * range_f / range_db + models.MIN_VOL_F
+  vol_f_clamped = clamp(vol_f, models.MIN_VOL_F, models.MAX_VOL_F)
   return vol_f_clamped


### PR DESCRIPTION
The front-panel display didn't get properly updated with the floating-point volume changes in the API. As well as fixing that issue, this PR makes is so that if 3 or more expanders are connected (>18 zones) the first 18 zone volumes are still displayed.