### PR TITLE
Populate more system info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## 0.1.X Upcoming
 * Web App
   * Add link for text log
+  * Add shutdown and reboot buttons in Settings->Configuration and Reset
 * API
+  * Add `api/shutdown` and `api/reboot` endpoints
 * Streams
 * Storage
   * Only log to RAM, drastically reducing disk writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Add shutdown and reboot buttons in Settings->Configuration and Reset
 * API
   * Add `api/shutdown` and `api/reboot` endpoints
+  * Add `api/info` endpoint for version, release, and other system information
 * Streams
 * Storage
   * Only log to RAM, drastically reducing disk writes
@@ -14,6 +15,11 @@
   * Use latest rapidoc viewer
 * Updates:
   * Upgrade system packages on update
+* System Status
+  * Detect if internet access is available (check 1.1.1.1 every 2 mins)
+  * Check in the background for available updates (once per day)
+* Developing:
+  * Show git hash and branch info for tests deployed by scripts/deploy
 
 ## 0.1.8
 * Web App

--- a/NEW_RELEASE.md
+++ b/NEW_RELEASE.md
@@ -1,0 +1,35 @@
+# How to make a new release of the AmpliPi software
+
+So you think you are ready to make a release, eh? Follow the steps below :)
+
+## Making a prelease
+- [ ] Merge main into develop
+- [ ] Make a branch off develop called VERSION-prelease
+- [ ] Update the changelog with notes and the latest version (and commit it!)
+- [ ] Use poetry to bump the version with `poetry version ${VERSION}-alpha0 && git commit -m "Bump pre-release version`
+- [ ] Tag the changes so we can make a pre-release on GH `git tag ${VERSION}-alpha0 && git push --tags`
+- [ ] Make a pre-release using the GH interface
+- [ ] Use the AmpliPi updater to update to the pre-release
+- [ ] Test it (See below), if it needs changes follow the steps above again but stay on the pre-release branch and increment the number after alpha eg `alpha8`
+- When it works skip below to #Finalizing the release
+
+## Testing
+- [ ] Web App (use chrome, firefox, and safari)
+  - [ ] Test group and zone volume control
+  - [ ] Check that each stream type can play music
+  - [ ] Test added app functionality
+- [ ] Android App
+  - [ ] Test added App functionality
+  - [ ] Verify group and zone volumes
+  - [ ] Check that each stream type can play music
+- [ ] Touchscreen display
+  - [ ] Verify touch turns display on
+  - [ ] Verify volume sliders work with app
+
+## Finalizing the release
+Alright so the release is tested and it actually works! Nice!
+- [ ] merge the prerelease branch into develop and merge that into the main branch
+- [ ] use poetry to bump the version `poetry version ${VERSION}` && `git commit -m "bump release"`
+- [ ] use git to delete any prelease tags `git push --delete-tags ${VERSION}-alpha*`
+- [ ] Tag the changes so we can make a release on GH `git tag ${VERSION} && git push --tags`
+- [ ] Make a release using the GH interface, add notes from the CHANGELOG.md

--- a/NEW_RELEASE.md
+++ b/NEW_RELEASE.md
@@ -6,12 +6,12 @@ So you think you are ready to make a release, eh? Follow the steps below :)
 - [ ] Merge main into develop
 - [ ] Make a branch off develop called VERSION-prelease
 - [ ] Update the changelog with notes and the latest version (and commit it!)
-- [ ] Use poetry to bump the version with `poetry version ${VERSION}-alpha0 && git commit -m "Bump pre-release version`
-- [ ] Tag the changes so we can make a pre-release on GH `git tag ${VERSION}-alpha0 && git push --tags`
-- [ ] Make a pre-release using the GH interface
+- [ ] Use poetry to bump the version with `poetry version ${VERSION}-alpha0 && git add pyproject.toml && git commit -m "Bump pre-release version"`
+- [ ] Tag the changes so we can make a pre-release on GitHub `git tag -as ${VERSION}-alpha0 -m '' && git push --follow-tags`
+- [ ] Make a pre-release using the GitHub interface
 - [ ] Use the AmpliPi updater to update to the pre-release
-- [ ] Test it (See below), if it needs changes follow the steps above again but stay on the pre-release branch and increment the number after alpha eg `alpha8`
-- When it works skip below to #Finalizing the release
+- [ ] Test it (see below), if it needs changes follow the steps above again but stay on the pre-release branch and increment the number after alpha eg `alpha8`
+- When it works skip below to [Finalizing the release](#finalizing-the-release)
 
 ## Testing
 - [ ] Web App (use chrome, firefox, and safari)
@@ -24,12 +24,19 @@ So you think you are ready to make a release, eh? Follow the steps below :)
   - [ ] Check that each stream type can play music
 - [ ] Touchscreen display
   - [ ] Verify touch turns display on
-  - [ ] Verify volume sliders work with app
+  - [ ] Verify sources and volume sliders work with app
+- [ ] Expanders
+  - [ ] Verify expanders are detected
+  - [ ] Test expander zone volume control
+- [ ] Tester
+  - [ ] Update end-of-line tester with new release
+  - [ ] Verify all tests function
 
 ## Finalizing the release
 Alright so the release is tested and it actually works! Nice!
 - [ ] merge the prerelease branch into develop and merge that into the main branch
-- [ ] use poetry to bump the version `poetry version ${VERSION}` && `git commit -m "bump release"`
-- [ ] use git to delete any prelease tags `git push --delete-tags ${VERSION}-alpha*`
-- [ ] Tag the changes so we can make a release on GH `git tag ${VERSION} && git push --tags`
-- [ ] Make a release using the GH interface, add notes from the CHANGELOG.md
+- [ ] use poetry to bump the version `poetry version ${VERSION} && git add pyproject.toml && git commit -m "Bump release"`
+- [ ] use git to delete any prelease tags `git push origin -d $(git tag -l '${VERSION}-alpha*') && git tag -d $(git tag -l '${VERSION}-alpha*')`
+- [ ] Tag the changes so we can make a release on GitHub `git tag -as ${VERSION} -m '' && git push --follow-tags`
+- [ ] Make a release using the GitHub interface, add notes from the CHANGELOG.md
+- [ ] Make a new Raspberry Pi image to program onto units before shipping.

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -459,7 +459,7 @@ def announce(announcement: models.Announcement, ctrl: Api = Depends(get_ctrl)) -
 
 # Info
 
-@api.post('/api/info', tags=['info'])
+@api.get('/api/info', tags=['status'])
 def get_info(ctrl: Api = Depends(get_ctrl)) -> models.Info:
   """ Get additional information """
   return code_response(ctrl, ctrl.get_info())

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -457,6 +457,13 @@ def announce(announcement: models.Announcement, ctrl: Api = Depends(get_ctrl)) -
   """ Make an announcement """
   return code_response(ctrl, ctrl.announce(announcement))
 
+# Info
+
+@api.post('/api/info', tags=['info'])
+def get_info(ctrl: Api = Depends(get_ctrl)) -> models.Info:
+  """ Get additional information """
+  return code_response(ctrl, ctrl.get_info())
+
 # include all routes above
 
 app.include_router(api)

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -207,8 +207,8 @@ class Api:
       config_file=self.config_file,
       version=utils.detect_version(),
     )
-    for major, minor, ghash, _ in self._rt.read_versions():
-      fw_info = models.FirmwareInfo(version=f'{major}.{minor}.', git_hash=f'{ghash:x}')
+    for major, minor, ghash, dirty in self._rt.read_versions():
+      fw_info = models.FirmwareInfo(version=f'{major}.{minor}', git_hash=f'{ghash:x}', git_dirty=dirty)
       self.status.info.fw.append(fw_info)
     self._update_sys_info() # TODO: does sys info need to be updated at init time?
 

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -319,6 +319,11 @@ class Api:
       inputs['stream={}'.format(stream.id)] = f'{stream.name} - {stream.type}'
     return inputs
 
+  def _update_sys_info(self) -> None:
+    """Update current system information"""
+    self.status.info.online = utils.is_online()
+    self.status.info.new_release = utils.latest_release()
+
   def get_state(self) -> models.Status:
     """ get the system state """
     # update the state with the latest stream info
@@ -335,7 +340,7 @@ class Api:
           stream.__dict__[field] = stream_inst.__dict__[field]
       streams.append(stream)
     self.status.streams = streams
-    # TODO: update systeminfo
+    self._update_sys_info()
     # update source's info
     # TODO: stream/source info should be updated in a background thread
     for src in self.status.sources:
@@ -344,6 +349,7 @@ class Api:
 
   def get_info(self) -> models.Info:
     """ Get the system information """
+    self._update_sys_info()
     if self.status.info is None:
       raise Exception("No info generated, system in a bad state")
     return self.status.info

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -335,6 +335,7 @@ class Api:
           stream.__dict__[field] = stream_inst.__dict__[field]
       streams.append(stream)
     self.status.streams = streams
+    # TODO: update systeminfo
     # update source's info
     # TODO: stream/source info should be updated in a background thread
     for src in self.status.sources:

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -333,8 +333,8 @@ class Api:
       status_dir = os.path.join(self.config_dir, 'status')
       with open(os.path.join(status_dir,'online'), encoding='utf-8') as fonline:
         online = 'online' in fonline.readline()
-    except Exception:
-      pass
+    except Exception as exc:
+      print(exc)
     return online
 
   def _check_latest_release(self) -> str:
@@ -345,8 +345,8 @@ class Api:
       with open(os.path.join(status_dir,'latest_release'), encoding='utf-8') as flatest:
         release = flatest.readline().strip()
         print(release)
-    except Exception:
-      pass
+    except Exception as exc:
+      print(exc)
     return release
 
   def _update_sys_info(self, throttled = True) -> None:

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -169,7 +169,7 @@ class Api:
     self.config_file = settings.config_file
     self.backup_config_file = settings.config_file + '.bak'
     self.config_file_valid = True # initially we assume the config file is valid
-    self.config_dir = os.path.dirname(self.config_file)
+    self.config_dir = os.path.join(os.path.dirname(self.config_file), 'config') # oddly the config file is outside the config directory
     errors = []
     if config:
       self.status = config

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -341,6 +341,12 @@ class Api:
       self._update_src_info(src)
     return self.status
 
+  def get_info(self) -> models.Info:
+    """ Get the system information """
+    if self.status.info is None:
+      raise Exception("No info generated, system in a bad state")
+    return self.status.info
+
   def get_items(self, tag: str) -> Optional[List[models.Base]]:
     """ Gets one of the lists of elements contained in status named by @t (or t's plural
 

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -38,7 +38,7 @@ import amplipi.utils as utils
 
 _DEBUG_API = False # print out a graphical state of the api after each call
 
-USER_CONFIG_DIR = os.path.join(os.path.expanduser('~'), '.cache', 'amplipi')
+USER_CACHE_DIR = os.path.join(os.path.expanduser('~'), '.cache', 'amplipi')
 
 @wrapt.decorator
 def save_on_success(wrapped, instance: 'Api', args, kwargs):
@@ -331,8 +331,7 @@ class Api:
   def _check_is_online(self) -> bool:
     online = False
     try:
-      status_dir = os.path.join(USER_CONFIG_DIR, 'status')
-      with open(os.path.join(status_dir,'online'), encoding='utf-8') as fonline:
+      with open(os.path.join(USER_CACHE_DIR, 'online'), encoding='utf-8') as fonline:
         online = 'online' in fonline.readline()
     except Exception as exc:
       pass
@@ -341,8 +340,7 @@ class Api:
   def _check_latest_release(self) -> str:
     release = 'unknown'
     try:
-      status_dir = os.path.join(USER_CONFIG_DIR, 'status')
-      with open(os.path.join(status_dir,'latest_release'), encoding='utf-8') as flatest:
+      with open(os.path.join(USER_CACHE_DIR, 'latest_release'), encoding='utf-8') as flatest:
         release = flatest.readline().strip()
     except Exception as exc:
       pass

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -206,7 +206,7 @@ class Api:
     for major, minor, ghash, _ in self._rt.read_versions():
       fw_info = models.FirmwareInfo(version=f'{major}.{minor}.', git_hash=f'{ghash:x}')
       self.status.info.fw.append(fw_info)
-    self._update_sys_info()
+    self._update_sys_info(throttled=False) # force update
 
     # detect missing zones
     if self._mock_hw:
@@ -324,12 +324,12 @@ class Api:
       inputs['stream={}'.format(stream.id)] = f'{stream.name} - {stream.type}'
     return inputs
 
-  def _update_sys_info(self) -> None:
+  def _update_sys_info(self, throttled=True) -> None:
     """Update current system information"""
     if self.status.info is None:
       raise Exception("No info generated, system in a bad state")
-    self.status.info.online = utils.is_online()
-    self.status.info.latest_release = utils.latest_release()
+    self.status.info.online = utils.is_online(throttled)
+    self.status.info.latest_release = utils.latest_release(throttled)
 
   def get_state(self) -> models.Status:
     """ get the system state """

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -38,6 +38,8 @@ import amplipi.utils as utils
 
 _DEBUG_API = False # print out a graphical state of the api after each call
 
+USER_CONFIG_DIR = os.path.join(os.path.expanduser('~'), '.cache', 'amplipi')
+
 @wrapt.decorator
 def save_on_success(wrapped, instance: 'Api', args, kwargs):
   """ Check if a ctrl API call is successful and saves the state if so """
@@ -169,7 +171,6 @@ class Api:
     self.config_file = settings.config_file
     self.backup_config_file = settings.config_file + '.bak'
     self.config_file_valid = True # initially we assume the config file is valid
-    self.config_dir = os.path.join(os.path.dirname(self.config_file), 'config') # oddly the config file is outside the config directory
     errors = []
     if config:
       self.status = config
@@ -330,23 +331,21 @@ class Api:
   def _check_is_online(self) -> bool:
     online = False
     try:
-      status_dir = os.path.join(self.config_dir, 'status')
+      status_dir = os.path.join(USER_CONFIG_DIR, 'status')
       with open(os.path.join(status_dir,'online'), encoding='utf-8') as fonline:
         online = 'online' in fonline.readline()
     except Exception as exc:
-      print(exc)
+      pass
     return online
 
   def _check_latest_release(self) -> str:
     release = 'unknown'
     try:
-      status_dir = os.path.join(self.config_dir, 'status')
-      print(f'reading from status_dir={status_dir}')
+      status_dir = os.path.join(USER_CONFIG_DIR, 'status')
       with open(os.path.join(status_dir,'latest_release'), encoding='utf-8') as flatest:
         release = flatest.readline().strip()
-        print(release)
     except Exception as exc:
-      print(exc)
+      pass
     return release
 
   def _update_sys_info(self, throttled = True) -> None:

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -734,9 +734,10 @@ class Announcement(BaseModel):
     }
 
 class FirmwareInfo(BaseModel):
-  """ Firmware Info for an AmpliPi controller or expansion unit """
-  version: str = Field(default='unknown', description="firmware version")
+  """ Firmware Info for an AmpliPi controller or expansion unit's preamp board """
+  version: str = Field(default='unknown', description="preamp firmware version")
   git_hash: str = Field(default='unknown', description="short git hash of firmware")
+  git_dirty: bool = Field(default=False, description="True if local changes were made. Used for development.")
 
 class Info(BaseModel):
   """ AmpliPi System information """
@@ -761,8 +762,9 @@ class Info(BaseModel):
             'latest_release': '0.1.8',
             'fw': [
               {
-                "version": "1.6.",
-                "git_hash": "de0f8eb"
+                "version": "1.6",
+                "git_hash": "de0f8eb",
+                "git_dirty": False,
               }
             ]
           }

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -742,8 +742,8 @@ class Info(BaseModel):
   sw_hash: str = Field(default='unknown', description="git hash of the commit the system is from")
   fw_version: str = Field(default='unknown', description="firmware version")
   fw_hash: str = Field(default='unknown', description="short git hash of firmware")
-  offline: bool = Field(default=True, description='can the system connect to the internet?')
-  new_release: bool = Field(default=False, description='Is a new, better release available?')
+  online: bool = Field(default=True, description='can the system connect to the internet?')
+  latest_release: str = Field(default='unknown', description='Latest software release available from GitHub')
 
 class Status(BaseModel):
   """ Full Controller Configuration and Status """

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -734,11 +734,16 @@ class Announcement(BaseModel):
     }
 
 class Info(BaseModel):
-  """ Information about the settings used by the controller """
-  config_file: str = 'Uknown'
-  version: str = 'Unknown'
-  mock_ctrl: bool = False
-  mock_streams: bool = False
+  """ AmpliPi System information """
+  version: str = Field(description="software version")
+  config_file: str = Field(default='unknown', description='config file location')
+  mock_ctrl: bool = Field(default=False, description='Is the controller being mocked? Indicates AmpliPi hardware is not connected')
+  mock_streams: bool = Field(default=False, description='Are streams being faked? Used for testing.')
+  sw_hash: str = Field(default='unknown', description="git hash of the commit the system is from")
+  fw_version: str = Field(default='unknown', description="firmware version")
+  fw_hash: str = Field(default='unknown', description="short git hash of firmware")
+  offline: bool = Field(default=True, description='can the system connect to the internet?')
+  new_release: bool = Field(default=False, description='Is a new, better release available?')
 
 class Status(BaseModel):
   """ Full Controller Configuration and Status """

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -733,17 +733,42 @@ class Announcement(BaseModel):
       }
     }
 
+class FirmwareInfo(BaseModel):
+  """ Firmware Info for an AmpliPi controller or expansion unit """
+  version: str = Field(default='unknown', description="firmware version")
+  git_hash: str = Field(default='unknown', description="short git hash of firmware")
+
 class Info(BaseModel):
   """ AmpliPi System information """
   version: str = Field(description="software version")
   config_file: str = Field(default='unknown', description='config file location')
   mock_ctrl: bool = Field(default=False, description='Is the controller being mocked? Indicates AmpliPi hardware is not connected')
   mock_streams: bool = Field(default=False, description='Are streams being faked? Used for testing.')
-  sw_hash: str = Field(default='unknown', description="git hash of the commit the system is from")
-  fw_version: str = Field(default='unknown', description="firmware version")
-  fw_hash: str = Field(default='unknown', description="short git hash of firmware")
-  online: bool = Field(default=True, description='can the system connect to the internet?')
+  online: bool = Field(default=False, description='can the system connect to the internet?')
   latest_release: str = Field(default='unknown', description='Latest software release available from GitHub')
+  fw: List[FirmwareInfo] = Field(default=[], description='firmware information for each connected controller or expansion unit')
+
+  class Config:
+    schema_extra = {
+      'examples': {
+        "System info": {
+          'value': {
+            'config_file': 'house.json',
+            'version': '0.1.8',
+            'mock_ctrl': False,
+            'mock_streams': False,
+            'online': True,
+            'latest_release': '0.1.8',
+            'fw': [
+              {
+                "version": "1.6.",
+                "git_hash": "de0f8eb"
+              }
+            ]
+          }
+        }
+      }
+    }
 
 class Status(BaseModel):
   """ Full Controller Configuration and Status """

--- a/amplipi/rt.py
+++ b/amplipi/rt.py
@@ -496,6 +496,10 @@ class Mock:
   def reset(self):
     pass
 
+  def read_versions(self) -> List[Tuple[int, int, int, bool]]:
+    """ Read the firmware information for all preamps (major, minor, hash, dirty?)"""
+    return []
+
   def update_sources(self, digital):
     """ modify all of the 4 system sources
 
@@ -583,6 +587,19 @@ class Rpi:
   def reset(self):
     """ Reset the firmware """
     self._bus.reset_preamps()
+
+  def read_versions(self) -> List[Tuple[int, int, int, bool]]:
+    """ Read the firmware information for all preamps (major, minor, hash, dirty?)"""
+    fw_versions: List[Tuple[int, int, int, bool]] = []
+    for i in range(1,6):
+      try:
+        infos = self._bus.read_version(i)
+        if infos[0] is None:
+          break
+        fw_versions.append(infos)
+      except:
+        break
+    return fw_versions
 
   def update_zone_mutes(self, zone, mutes):
     """ Update the mute level to all of the zones

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -256,15 +256,20 @@ _last_release_check = 0
 def latest_release():
   """Throttled check for latest release, throttle allows for simple polling by controller"""
   global _latest_release, _last_release_check
-  if time.time() > _last_release_check + 60:
+  now = time.time()
+  if now > _last_release_check + 60:
     status_dir = f"{get_folder('config')}/status"
     _latest_release = 'unknown'
     _last_release_check = time.time()
     try:
+      print('checking latest release')
       with open(os.path.join(status_dir,'latest_release'), encoding='utf-8') as flatest:
         _latest_release = flatest.readline().strip()
-    except Exception:
+    except Exception as exc:
+      print(f'Error getting latest_release: {exc}')
       pass
+  else:
+    print(f'using cached latest release {now} (now) <= {_last_release_check} + 60')
   return _latest_release
 
 def vol_float_to_db(vol: float, db_min: int = models.MIN_VOL_DB, db_max: int = models.MAX_VOL_DB) -> int:

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -239,9 +239,11 @@ _is_online = False
 _last_online_check = time.time()
 def is_online():
   """Throttled check if the system is conencted to the internet, throttle allows for simple polling by controller"""
+  global _is_online, _last_online_check
   if time.time() > _last_online_check + 2:
     status_dir = f"{get_folder('config')}/status"
     _is_online = False
+    _last_online_check = time.time()
     try:
       with open(os.path.join(status_dir,'online'), encoding='utf-8') as fonline:
         _is_online = 'online' in fonline.readline()
@@ -253,12 +255,14 @@ _latest_release = 'unknown'
 _last_release_check = time.time()
 def latest_release():
   """Throttled check for latest release, throttle allows for simple polling by controller"""
+  global _latest_release, _last_release_check
   if time.time() > _last_release_check + 60:
     status_dir = f"{get_folder('config')}/status"
     _latest_release = 'unknown'
+    _last_release_check = time.time()
     try:
       with open(os.path.join(status_dir,'latest_release'), encoding='utf-8') as flatest:
-        _latest_release = flatest.readline()
+        _latest_release = flatest.readline().strip()
     except Exception:
       pass
   return _latest_release

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -237,7 +237,8 @@ def is_amplipi():
 
 class TimeBasedCache:
   """ Cache the value of a timely but costly method, @updater, for @keep_for s """
-  def __init__(self,  updater, keep_for:float):
+  def __init__(self,  updater, keep_for:float, name):
+    self.name = name
     self._updater = updater
     self._keep_for = keep_for
     self._update()
@@ -250,7 +251,10 @@ class TimeBasedCache:
     """ Get the potentially cached value """
     now = time.time()
     if now > self._last_check + self._keep_for:
+      print(f'updating cach for {self.name}')
       self._update()
+    else:
+      print(f'using cached value for {self.name}')
     return self._val
 
 def _get_online() -> bool:
@@ -263,7 +267,7 @@ def _get_online() -> bool:
     pass
   return online
 
-_online_cache = TimeBasedCache(_get_online, 5)
+_online_cache = TimeBasedCache(_get_online, 5, 'online')
 def is_online() -> bool:
   """Throttled check if the system is conencted to the internet, throttle allows for simple polling by controller"""
   return _online_cache.get()
@@ -278,7 +282,7 @@ def _get_latest_release() -> str:
     pass
   return release
 
-_latest_release_cache = TimeBasedCache(_get_latest_release, 3600)
+_latest_release_cache = TimeBasedCache(_get_latest_release, 3600, 'latest release')
 
 def latest_release():
   """Throttled check for latest release, throttle allows for simple polling by controller"""

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -236,7 +236,7 @@ def is_amplipi():
   return amplipi
 
 _is_online = False
-_last_online_check = time.time()
+_last_online_check = 0
 def is_online():
   """Throttled check if the system is conencted to the internet, throttle allows for simple polling by controller"""
   global _is_online, _last_online_check
@@ -252,7 +252,7 @@ def is_online():
   return _is_online
 
 _latest_release = 'unknown'
-_last_release_check = time.time()
+_last_release_check = 0
 def latest_release():
   """Throttled check for latest release, throttle allows for simple polling by controller"""
   global _latest_release, _last_release_check

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -251,42 +251,8 @@ class TimeBasedCache:
     """ Get the potentially cached value """
     now = time.time()
     if not throttled or now > self._last_check + self._keep_for:
-      print(f'updating cach for {self.name}')
       self._update()
-    else:
-      print(f'using cached value for {self.name}')
     return self._val
-
-def _get_online() -> bool:
-  online = False
-  try:
-    status_dir = os.path.join(get_folder('config'),'status')
-    with open(os.path.join(status_dir,'online'), encoding='utf-8') as fonline:
-      online = 'online' in fonline.readline()
-  except Exception:
-    pass
-  return online
-
-_online_cache = TimeBasedCache(_get_online, 5, 'online')
-def is_online(throttled=True) -> bool:
-  """Throttled check if the system is conencted to the internet, throttle allows for simple polling by controller"""
-  return _online_cache.get(throttled)
-
-def _get_latest_release() -> str:
-  release = 'unknown'
-  try:
-    status_dir = os.path.join(get_folder('config'),'status')
-    with open(os.path.join(status_dir,'latest_release'), encoding='utf-8') as flatest:
-      release = flatest.readline().strip()
-  except Exception:
-    pass
-  return release
-
-_latest_release_cache = TimeBasedCache(_get_latest_release, 3600, 'latest release')
-
-def latest_release(throttled=True):
-  """Throttled check for latest release, throttle allows for simple polling by controller"""
-  return _latest_release_cache.get(throttled)
 
 def vol_float_to_db(vol: float, db_min: int = models.MIN_VOL_DB, db_max: int = models.MAX_VOL_DB) -> int:
   """ Convert floating-point volume to dB """

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -247,10 +247,10 @@ class TimeBasedCache:
     self._val = self._updater()
     self._last_check = time.time()
 
-  def get(self):
+  def get(self, throttled=True):
     """ Get the potentially cached value """
     now = time.time()
-    if now > self._last_check + self._keep_for:
+    if not throttled or now > self._last_check + self._keep_for:
       print(f'updating cach for {self.name}')
       self._update()
     else:
@@ -268,9 +268,9 @@ def _get_online() -> bool:
   return online
 
 _online_cache = TimeBasedCache(_get_online, 5, 'online')
-def is_online() -> bool:
+def is_online(throttled=True) -> bool:
   """Throttled check if the system is conencted to the internet, throttle allows for simple polling by controller"""
-  return _online_cache.get()
+  return _online_cache.get(throttled)
 
 def _get_latest_release() -> str:
   release = 'unknown'
@@ -284,9 +284,9 @@ def _get_latest_release() -> str:
 
 _latest_release_cache = TimeBasedCache(_get_latest_release, 3600, 'latest release')
 
-def latest_release():
+def latest_release(throttled=True):
   """Throttled check for latest release, throttle allows for simple polling by controller"""
-  return _latest_release_cache.get()
+  return _latest_release_cache.get(throttled)
 
 def vol_float_to_db(vol: float, db_min: int = models.MIN_VOL_DB, db_max: int = models.MAX_VOL_DB) -> int:
   """ Convert floating-point volume to dB """

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -22,7 +22,7 @@ This module contains helper functions are used across the amplipi python library
 import functools
 import io
 import json
-import math
+import time
 import os
 import re
 import subprocess
@@ -234,6 +234,34 @@ def is_amplipi():
     amplipi = False
 
   return amplipi
+
+_is_online = False
+_last_online_check = time.time()
+def is_online():
+  """Throttled check if the system is conencted to the internet, throttle allows for simple polling by controller"""
+  if time.time() > _last_online_check + 2:
+    status_dir = f"{get_folder('config')}/status"
+    _is_online = False
+    try:
+      with open(os.path.join(status_dir,'online'), encoding='utf-8') as fonline:
+        _is_online = 'online' in fonline.readline()
+    except Exception:
+      pass
+  return _is_online
+
+_latest_release = 'unknown'
+_last_release_check = time.time()
+def latest_release():
+  """Throttled check for latest release, throttle allows for simple polling by controller"""
+  if time.time() > _last_release_check + 60:
+    status_dir = f"{get_folder('config')}/status"
+    _latest_release = 'unknown'
+    try:
+      with open(os.path.join(status_dir,'latest_release'), encoding='utf-8') as flatest:
+        _latest_release = flatest.readline()
+    except Exception:
+      pass
+  return _latest_release
 
 def vol_float_to_db(vol: float, db_min: int = models.MIN_VOL_DB, db_max: int = models.MAX_VOL_DB) -> int:
   """ Convert floating-point volume to dB """

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -166,7 +166,7 @@ def enabled_zones(status: models.Status, zones: Set[int]) -> Set[int]:
 @functools.lru_cache(maxsize=8)
 def get_folder(folder):
   """ Get a directory
-  Abstracts the directory structure """
+  Abstracts the directory structure. TODO: This does not find the correct directory when testing. """
   if not os.path.exists(folder):
     try:
       os.mkdir(folder)

--- a/scripts/check-online
+++ b/scripts/check-online
@@ -2,19 +2,20 @@
 # Update the offline/online state
 set -e
 
-USER_CACHE_DIR="$HOME/.cache/amplipi"
+USER_CACHE_DIR="${HOME}/.cache/amplipi"
+ONLINE_FILE="${USER_CACHE_DIR}/online"
 
 # add file if needed
-if [ ! -e $USER_CACHE_DIR/online ]; then
-  mkdir -p $USER_CACHE_DIR
-  touch $USER_CACHE_DIR/online
+if [ ! -e "${ONLINE_FILE}" ]; then
+  mkdir -p "${USER_CACHE_DIR}"
+  touch "${ONLINE_FILE}"
 fi
 
 # Check if we can reach the internet without dns
-last_online=$(cat $USER_CACHE_DIR/online)
+last_online=$(cat "${ONLINE_FILE}")
 online=$(nc -w 5 -z 1.1.1.1 53 >/dev/null 2>&1 && echo online || echo offline)
 
 # only update online state as needed
-if [ "$last_online" != "$online" ]; then
-  echo "$online" > $USER_CACHE_DIR/online
+if [ "${last_online}" != "${online}" ]; then
+  echo "${online}" > "${ONLINE_FILE}"
 fi

--- a/scripts/check-online
+++ b/scripts/check-online
@@ -12,8 +12,8 @@ if [ ! -e ../config/status/online ]; then
 fi
 
 # Check if we can reach the internet without dns
-last_online=`cat ../config/status/online`
-online=`nc -w 5 -z 1.1.1.1 53 >/dev/null 2>&1 && echo online || echo offline`
+last_online=$(cat ../config/status/online)
+online=$(nc -w 5 -z 1.1.1.1 53 >/dev/null 2>&1 && echo online || echo offline)
 
 # only update online state as needed
 if [ "$last_online" != "$online" ]; then

--- a/scripts/check-online
+++ b/scripts/check-online
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Update the offline/online state
+set -e
+
+# get directory that the script exists in
+cd "$( dirname "$0" )"
+
+# add file if needed
+if [ ! -e ../config/status/online ]; then
+  mkdir -p ../config/status
+  touch ../config/status/online
+fi
+
+# Check if we can reach the internet without dns
+last_online=`cat ../config/status/online`
+online=`nc -w 5 -z 1.1.1.1 53 >/dev/null 2>&1 && echo online || echo offline`
+
+# only update online state as needed
+if [ "$last_online" != "$online" ]; then
+  echo "$online" > ../config/status/online
+fi

--- a/scripts/check-online
+++ b/scripts/check-online
@@ -2,20 +2,19 @@
 # Update the offline/online state
 set -e
 
-# get directory that the script exists in
-cd "$( dirname "$0" )"
+USER_CACHE_DIR="$HOME/.cache/amplipi"
 
 # add file if needed
-if [ ! -e ../config/status/online ]; then
-  mkdir -p ../config/status
-  touch ../config/status/online
+if [ ! -e $USER_CACHE_DIR/online ]; then
+  mkdir -p $USER_CACHE_DIR
+  touch $USER_CACHE_DIR/online
 fi
 
 # Check if we can reach the internet without dns
-last_online=$(cat ../config/status/online)
+last_online=$(cat $USER_CACHE_DIR/online)
 online=$(nc -w 5 -z 1.1.1.1 53 >/dev/null 2>&1 && echo online || echo offline)
 
 # only update online state as needed
 if [ "$last_online" != "$online" ]; then
-  echo "$online" > ../config/status/online
+  echo "$online" > $USER_CACHE_DIR/online
 fi

--- a/scripts/check-release
+++ b/scripts/check-release
@@ -12,8 +12,8 @@ if [ ! -e ../config/status/latest_release ]; then
 fi
 
 # update the latest release if new
-previous_release=`cat ../config/status/latest_release`
-latest_release=`curl -s https://api.github.com/repos/micro-nova/AmpliPi/releases/latest | jq -r ".tag_name"`
+previous_release=$(cat ../config/status/latest_release)
+latest_release=$(curl -s https://api.github.com/repos/micro-nova/AmpliPi/releases/latest | jq -r ".tag_name")
 if [ "$latest_release" != "" ] && [ "$latest_release" != "null" ] && [ "$latest_release" != "$previous_release" ]; then
    mkdir -p ../config/status
    echo "$latest_release" > ../config/status/latest_release

--- a/scripts/check-release
+++ b/scripts/check-release
@@ -2,18 +2,18 @@
 # Update the latest release
 set -e
 
-USER_CACHE_DIR="$HOME/.cache/amplipi"
+USER_CACHE_DIR="${HOME}/.cache/amplipi"
+LATEST_RELEASE_FILE="${USER_CACHE_DIR}/latest_release"
 
 # add file if needed
-if [ ! -e $USER_CACHE_DIR/latest_release ]; then
-  mkdir -p $USER_CACHE_DIR
-  touch $USER_CACHE_DIR/latest_release
+if [ ! -e "${LATEST_RELEASE_FILE}" ]; then
+  mkdir -p "${USER_CACHE_DIR}"
+  touch "${LATEST_RELEASE_FILE}"
 fi
 
 # update the latest release if new
-previous_release=$(cat $USER_CACHE_DIR/latest_release)
-latest_release=$(curl -s https://api.github.com/repos/micro-nova/AmpliPi/releases/latest | jq -r ".tag_name")
-if [ "$latest_release" != "" ] && [ "$latest_release" != "null" ] && [ "$latest_release" != "$previous_release" ]; then
-   mkdir -p $USER_CACHE_DIR
-   echo "$latest_release" > $USER_CACHE_DIR/latest_release
+prev_release=$(cat "${LATEST_RELEASE_FILE}")
+cur_release=$(curl -s https://api.github.com/repos/micro-nova/AmpliPi/releases/latest | jq -r ".tag_name")
+if [ "${cur_release}" != "" ] && [ "${cur_release}" != "null" ] && [ "${cur_release}" != "${prev_release}" ]; then
+   echo "${cur_release}" > "${LATEST_RELEASE_FILE}"
 fi

--- a/scripts/check-release
+++ b/scripts/check-release
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Update the latest release
+set -e
+
+# get directory that the script exists in
+cd "$( dirname "$0" )"
+
+# add file if needed
+if [ ! -e ../config/status/latest_release ]; then
+  mkdir -p ../config/status
+  touch ../config/status/latest_release
+fi
+
+# update the latest release if new
+previous_release=`cat ../config/status/latest_release`
+latest_release=`curl -s https://api.github.com/repos/micro-nova/AmpliPi/releases/latest | jq -r ".tag_name"`
+if [ "$latest_release" != "" ] && [ "$latest_release" != "null" ] && [ "$latest_release" != "$previous_release" ]; then
+   mkdir -p ../config/status
+   echo "$latest_release" > ../config/status/latest_release
+fi

--- a/scripts/check-release
+++ b/scripts/check-release
@@ -2,19 +2,18 @@
 # Update the latest release
 set -e
 
-# get directory that the script exists in
-cd "$( dirname "$0" )"
+USER_CACHE_DIR="$HOME/.cache/amplipi"
 
 # add file if needed
-if [ ! -e ../config/status/latest_release ]; then
-  mkdir -p ../config/status
-  touch ../config/status/latest_release
+if [ ! -e $USER_CACHE_DIR/latest_release ]; then
+  mkdir -p $USER_CACHE_DIR
+  touch $USER_CACHE_DIR/latest_release
 fi
 
 # update the latest release if new
-previous_release=$(cat ../config/status/latest_release)
+previous_release=$(cat $USER_CACHE_DIR/latest_release)
 latest_release=$(curl -s https://api.github.com/repos/micro-nova/AmpliPi/releases/latest | jq -r ".tag_name")
 if [ "$latest_release" != "" ] && [ "$latest_release" != "null" ] && [ "$latest_release" != "$previous_release" ]; then
-   mkdir -p ../config/status
-   echo "$latest_release" > ../config/status/latest_release
+   mkdir -p $USER_CACHE_DIR
+   echo "$latest_release" > $USER_CACHE_DIR/latest_release
 fi

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -260,7 +260,7 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
 
   # Upgrade current packages
   print_progress([Task("upgrading debian packages, this will take 10+ minutes", success=True)])
-  tasks += print_progress([Task('upgrade debian packages', 'sudo apt-get upgrade --assume-yes'.split()).run()])
+  tasks += print_progress([Task('upgrade debian packages', 'sudo apt upgrade --assume-yes'.split()).run()])
 
   # organize stuff to install
   packages = set()

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -84,9 +84,7 @@ _os_deps: Dict[str, Dict[str, Any]] = {
              'stm32flash',                  # Programming Preamp Board
              'xkcdpass',                    # Random passphrase generation
              'systemd-journal-remote',      # Remote/web based log access
-             # kernel updates
-             'libraspberrypi0', 'raspberrypi-bootloader', 'raspberrypi-kernel',
-             'libraspberrypi-bin', 'libraspberrypi-dev', 'libraspberrypi-doc',
+             'jq',                          # JSON parser used in check-release script
             ],
   },
   'web' : {

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -315,6 +315,8 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
       return tasks
     # setup tmpfs (ram disk)
     tasks += print_progress(_setup_tmpfs(env['base_dir']))
+    # setup crontab
+    tasks += print_progress([Task("Setting up crontab", [f"cat {env['base_dir']}/scripts/crontab | sed 's@SCRIPTS_DIR@{env['base_dir']}/scripts@' | crontab"], shell=True).run()])
   # install debian packages
   tasks += print_progress([Task('install debian packages', 'sudo apt-get install -y'.split() + list(packages)).run()])
 

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -1,10 +1,7 @@
 # Recurring os tasks handled by cron
 # installed by amplipi
-
-SHELL=/bin/bash
-
 # m   h  dom mon dow   command
-#                      avoid overloading GitHub
-  0   5  *   *   *     sleep ${RANDOM:0:2}m; SCRIPTS_DIR/check-release
-#                      avoid exact period
-  */5 *  *   *   *     sleep 0.${RANDOM:0:2}s; SCRIPTS_DIR/check-online
+#                      Check for new release, add jitter to avoid overloading GitHub.
+  0   5  *   *   *     sleep $(tr -cd 0-9 </dev/urandom | head -c 3)s; SCRIPTS_DIR/check-release
+#                      Check for internet access.
+  */5 *  *   *   *     SCRIPTS_DIR/check-online

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -1,0 +1,5 @@
+# Recurring os tasks handled by cron
+# installed by amplipi when a release
+# m   h  dom mon dow   command
+  0   5  *   *   *     SCRIPTS_DIR/check-release
+  */2 *  *   *   *     SCRIPTS_DIR/check-online

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -1,5 +1,8 @@
 # Recurring os tasks handled by cron
-# installed by amplipi when a release
+# installed by amplipi
+
+SHELL=/bin/bash
+
 # m   h  dom mon dow   command
 #                      avoid overloading GitHub
   0   5  *   *   *     sleep ${RANDOM:0:2}m; SCRIPTS_DIR/check-release

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -1,5 +1,7 @@
 # Recurring os tasks handled by cron
 # installed by amplipi when a release
 # m   h  dom mon dow   command
-  0   5  *   *   *     SCRIPTS_DIR/check-release
-  */2 *  *   *   *     SCRIPTS_DIR/check-online
+#                      avoid overloading GitHub
+  0   5  *   *   *     sleep ${RANDOM:0:2}m; SCRIPTS_DIR/check-release
+#                      avoid exact period
+  */5 *  *   *   *     sleep 0.${RANDOM:0:2}s; SCRIPTS_DIR/check-online

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -9,19 +9,16 @@ cd "$( dirname "$0" )"
 HELP="Install/Update AmpliPi software on a remote system defined by USER@HOST (default: pi@amplipi.local)\n
   usage: deploy [USER@HOST] [--mock-ctrl]\n
 \n
-  --dev: add info to version showing the current git hash and branch\n
   --fw:  program the latest preamp firmware\n
   --pw:  generate and set a new random password\n
 "
 
 user_host='pi@amplipi.local'
 user_host_set=false
-dev=false
 fw=false
 pw=false
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-    --dev) dev=true ;;
     --fw) fw=true ;;
     --pw) pw=true ;;
     -h|--help) echo -e $HELP; exit 0 ;;
@@ -39,7 +36,6 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 printf "Deploying amplipi project "
-$dev && printf "(development build) "
 printf "to $user_host.\n"
 printf "Preamp firmware will "
 $fw || printf "NOT "
@@ -118,18 +114,19 @@ if ! $mock_ctrl; then
   sed -i 's/DISABLE_HW = True/DISABLE_HW = False/' ../amplipi/rt.py
 fi
 
-if $dev; then
-  old_version=$(poetry version -s)
-  # git_info="$(git describe --always --dirty)-$(git rev-parse --abbrev-ref HEAD)"
-  # TODO: write extra git info to the pyproject.toml file since poetry complains about non-standard versions
-  poetry version prerelease
-fi
+# use a new version for the build but hide it from git since it isn't a real release
+old_version=$(poetry version -s)
+# parse the git info into: VERSION+GIT_HASH-BRANCH_NAME-DIRTY?
+# git describe gets us close to this: VERSION-NUM_COMMITS_SINCE-GIT-HASH-DIRTY?
+#  but we need to change it a bit to remove NUM_COMMITS and add BRANCH_NAME
+git_info=$(git describe --always --tags --dirty | sed -E s/-[0-9]*-*/+/ | sed s/-/-$(git rev-parse --abbrev-ref HEAD)-/)
+poetry version ${git_info}
+
 # build release file (put in dist/)
 poetry build
 
-if $dev; then
-  poetry version $old_version
-fi
+# revert to the old version so we don't modify extra files (the modified version info is in the build already)
+poetry version $old_version
 
 # exit virtual environment
 deactivate

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -116,10 +116,29 @@ fi
 
 # use a new version for the build but hide it from git since it isn't a real release
 old_version=$(poetry version -s)
-# parse the git info into: VERSION+GIT_HASH-BRANCH_NAME-DIRTY?
-# git describe gets us close to this: VERSION-NUM_COMMITS_SINCE-GIT-HASH-DIRTY?
-#  but we need to change it a bit to remove NUM_COMMITS and add BRANCH_NAME
-git_info=$(git describe --always --tags --dirty --match '*.*.*' | sed -E s/-[0-9]*-*/+/ | sed s/-/-$(git rev-parse --abbrev-ref HEAD)-/)
+# parse the git info into: VERSION+GIT_HASH-BRANCH_NAME[-dirty]
+# 'git describe' searches the git commit tree for the latest version tag.
+# The only guaranteed output is the 7-character short commit hash of the current commit,
+# but typically git describe outputs VERSION-N-gHASH[-dirty].
+# --always means even if no tag was found still generate an output: HASH[-dirty]
+# --tags causes all tags to match, not just annotated
+# --dirty appends -dirty if there are changes to tracked files or stashed changes
+# --long forces -N-gHASH to be printed even if tagged commit is checked out
+# --match '*.*.*' matches tags with *.*.* format (rules out fw/*)
+git_description=$(git describe --always --tags --dirty --long --match '*.*.*' 2>/dev/null)
+if [[ -z $git_description ]]; then
+  # not a git repo, use poetry version and indicate unkown development state
+  git_info="$old_version+unknown"
+else
+  git_version=$(echo "$git_description" | sed -nE 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+  # anything before the first tag will be an empty string, so define that as ver 0.0.0
+  [[ -z $git_version ]] && git_version=0.0.0
+  # the hash is by default 7 hex chars, but could be more if required to avoid collisions
+  git_hash=$(echo "$git_description" | sed -E 's/.*([0-9a-f]{7,}).*/\1/')
+  git_branch=$(git symbolic-ref --short HEAD 2>/dev/null) && git_branch="-$git_branch"
+  git_dirty=$(echo "$git_description" | sed -n 's/.*-dirty/-dirty/p')
+  git_info="$git_version+$git_hash$git_branch$git_dirty"
+fi
 poetry version ${git_info}
 
 # build release file (put in dist/)

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -65,7 +65,9 @@ if ! $found; then
   echo "  Some users on windows 10 have reported MDNS does not work over Wifi. Try using a wired connection."
   exit 1;
 fi
+
 # install dependencies as necessary
+echo -e "\nChecking dependencies"
 inst=false
 python='python'
 if which dpkg; then
@@ -93,9 +95,9 @@ else
     exit 1;
   fi
 fi
+
 # create a virtual environment and install pip dependencies
-if [[ ! -d ../venv ]] || [[ ! -e ../venv/bin/activate ]] && [[ ! -e ../venv/Scripts/activate
-]]; then
+if [[ ! -d ../venv ]] || [[ ! -e ../venv/bin/activate ]] && [[ ! -e ../venv/Scripts/activate ]]; then
   echo  ""
   echo "Setting up virtual environment"
   mkdir -p ../venv
@@ -108,6 +110,7 @@ else
 fi
 $python -m pip install --upgrade pip
 $python -m pip install poetry
+echo -e "Finished checking dependencies\n"
 
 if ! $mock_ctrl; then
   # set ENABLE_HW flag since this is being deployed to a machine with the actual hardware setup
@@ -121,11 +124,11 @@ old_version=$(poetry version -s)
 # The only guaranteed output is the 7-character short commit hash of the current commit,
 # but typically git describe outputs VERSION-N-gHASH[-dirty].
 # --always means even if no tag was found still generate an output: HASH[-dirty]
-# --tags causes all tags to match, not just annotated
 # --dirty appends -dirty if there are changes to tracked files or stashed changes
 # --long forces -N-gHASH to be printed even if tagged commit is checked out
 # --match '*.*.*' matches tags with *.*.* format (rules out fw/*)
-git_description=$(git describe --always --tags --dirty --long --match '*.*.*' 2>/dev/null)
+# || true effectively ignores the exit condition of git describe
+git_description=$(git describe --always --dirty --long --match '*.*.*' 2>/dev/null) || true
 if [[ -z $git_description ]]; then
   # not a git repo, use poetry version and indicate unkown development state
   git_info="$old_version+unknown"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -119,7 +119,7 @@ old_version=$(poetry version -s)
 # parse the git info into: VERSION+GIT_HASH-BRANCH_NAME-DIRTY?
 # git describe gets us close to this: VERSION-NUM_COMMITS_SINCE-GIT-HASH-DIRTY?
 #  but we need to change it a bit to remove NUM_COMMITS and add BRANCH_NAME
-git_info=$(git describe --always --tags --dirty | sed -E s/-[0-9]*-*/+/ | sed s/-/-$(git rev-parse --abbrev-ref HEAD)-/)
+git_info=$(git describe --always --tags --dirty --match '*.*.*' | sed -E s/-[0-9]*-*/+/ | sed s/-/-$(git rev-parse --abbrev-ref HEAD)-/)
 poetry version ${git_info}
 
 # build release file (put in dist/)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -124,6 +124,7 @@ def client(request):
   """ AmpliPi instance with mocked ctrl and streams """
   cfg = request.param
   config_dir = tempfile.mkdtemp()
+  # write a valid version to the cache directory, needed by test_get_info
   status_dir = amplipi.ctrl.USER_CACHE_DIR
   os.makedirs(status_dir, exist_ok=True)
   with open(os.path.join(status_dir, 'latest_release'), 'w', encoding='utf-8') as version_file:
@@ -142,6 +143,7 @@ def clientnm(request):# Non-mock systems should use this client - mock_ctrl and 
   cfg = request.param
   config_dir = tempfile.mkdtemp()
   config_file = os.path.join(config_dir, 'house.json')
+  # write a valid version to the cache directory, needed by test_get_info
   status_dir = amplipi.ctrl.USER_CACHE_DIR
   os.makedirs(status_dir, exist_ok=True)
   with open(os.path.join(status_dir, 'latest_release'), 'w', encoding='utf-8') as version_file:

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -227,6 +227,17 @@ def test_open_api_yamlfile(client):
 # To reduce the amount of boilerplate we use test parameters.
 # Examples: https://docs.pytest.org/en/stable/example/parametrize.html#paramexamples
 
+# Test Status
+def test_info(client):
+  """ Check the system information """
+  rv = client.get(f'/api/info')
+  assert rv.status_code == HTTPStatus.OK
+  jrv = rv.json()
+  for val in jrv.values():
+    assert val is not None
+    if isinstance(val, str):
+      assert val.lower() != 'unknown', "Unpopulated info field"
+
 # Test Sources
 def base_source_ids():
   """ Default Source ids """

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -236,6 +236,7 @@ def test_open_api_yamlfile(client):
 def test_get_info(client):
   """ Check the system information """
   rv = client.get(f'/api/info')
+  print('getting info')
   assert rv.status_code == HTTPStatus.OK
   jrv = rv.json()
   for key, val in jrv.items():

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -124,7 +124,7 @@ def client(request):
   """ AmpliPi instance with mocked ctrl and streams """
   cfg = request.param
   config_dir = tempfile.mkdtemp()
-  status_dir = os.path.join(config_dir,'status')
+  status_dir = os.path.join(config_dir,'config', 'status')
   os.makedirs(status_dir)
   with open(os.path.join(status_dir, 'latest_release'), 'w', encoding='utf-8') as version_file:
     version_file.write('0.1.8\n')
@@ -142,7 +142,7 @@ def clientnm(request):# Non-mock systems should use this client - mock_ctrl and 
   cfg = request.param
   config_dir = tempfile.mkdtemp()
   config_file = os.path.join(config_dir, 'house.json')
-  status_dir = os.path.join(config_dir,'status')
+  status_dir = os.path.join(config_dir,'config', 'status')
   os.makedirs(status_dir)
   with open(os.path.join(status_dir, 'latest_release'), 'w', encoding='utf-8') as version_file:
     version_file.write('0.1.8\n')

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -124,6 +124,10 @@ def client(request):
   """ AmpliPi instance with mocked ctrl and streams """
   cfg = request.param
   config_dir = tempfile.mkdtemp()
+  status_dir = os.path.join(config_dir,'status')
+  os.makedirs(status_dir)
+  with open(os.path.join(status_dir, 'latest_version'), 'w') as version_file:
+    version_file.write('0.1.8\n')
   config_file = os.path.join(config_dir, 'house.json')
   with open(config_file, 'w') as cfg_file:
     cfg_file.write(json.dumps(cfg))

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -136,7 +136,7 @@ def client(request):
   c.original_config = deepcopy(cfg) # add the loaded config so we can remember what was loaded
   return c
 
-@pytest.fixture(params=[base_config_copy(), base_config_no_presets(), base_config_no_groups()])
+@pytest.fixture(params=[base_config_copy(), base_config_no_presets(), base_config_no_groups(), base_config_no_streams(), base_config_vol_db()])
 def clientnm(request):# Non-mock systems should use this client - mock_ctrl and mock_streams are False here
   """ AmpliPi instance connected to a real AmpliPi controller """
   cfg = request.param

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -126,10 +126,10 @@ def client(request):
   config_dir = tempfile.mkdtemp()
   status_dir = os.path.join(config_dir,'status')
   os.makedirs(status_dir)
-  with open(os.path.join(status_dir, 'latest_version'), 'w') as version_file:
+  with open(os.path.join(status_dir, 'latest_release'), 'w', encoding='utf-8') as version_file:
     version_file.write('0.1.8\n')
   config_file = os.path.join(config_dir, 'house.json')
-  with open(config_file, 'w') as cfg_file:
+  with open(config_file, 'w', encoding='utf') as cfg_file:
     cfg_file.write(json.dumps(cfg))
   app = amplipi.app.create_app(mock_ctrl=True, mock_streams=True, config_file=config_file, delay_saves=False)
   c = TestClient(app)
@@ -142,6 +142,10 @@ def clientnm(request):# Non-mock systems should use this client - mock_ctrl and 
   cfg = request.param
   config_dir = tempfile.mkdtemp()
   config_file = os.path.join(config_dir, 'house.json')
+  status_dir = os.path.join(config_dir,'status')
+  os.makedirs(status_dir)
+  with open(os.path.join(status_dir, 'latest_release'), 'w', encoding='utf-8') as version_file:
+    version_file.write('0.1.8\n')
   with open(config_file, 'w') as cfg_file:
     cfg_file.write(json.dumps(cfg))
   app = amplipi.app.create_app(mock_ctrl=False, mock_streams=False, config_file=config_file, delay_saves=False)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -229,15 +229,15 @@ def test_open_api_yamlfile(client):
 # Examples: https://docs.pytest.org/en/stable/example/parametrize.html#paramexamples
 
 # Test Status
-def test_info(client):
+def test_get_info(client):
   """ Check the system information """
   rv = client.get(f'/api/info')
   assert rv.status_code == HTTPStatus.OK
   jrv = rv.json()
-  for val in jrv.values():
-    assert val is not None, "Unpopulated info field, expected value got 'None'"
+  for key, val in jrv.items():
+    assert val is not None, f"Unpopulated info field {key}, expected value got 'None'"
     if isinstance(val, str):
-      assert val.lower() != 'unknown', "Unpopulated info field"
+      assert val.lower() != 'unknown', f"Unpopulated info field {key}"
 
 # Test Sources
 def base_source_ids():

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -124,8 +124,8 @@ def client(request):
   """ AmpliPi instance with mocked ctrl and streams """
   cfg = request.param
   config_dir = tempfile.mkdtemp()
-  status_dir = os.path.join(config_dir,'config', 'status')
-  os.makedirs(status_dir)
+  status_dir = amplipi.ctrl.USER_CACHE_DIR
+  os.makedirs(status_dir, exist_ok=True)
   with open(os.path.join(status_dir, 'latest_release'), 'w', encoding='utf-8') as version_file:
     version_file.write('0.1.8\n')
   config_file = os.path.join(config_dir, 'house.json')
@@ -142,8 +142,8 @@ def clientnm(request):# Non-mock systems should use this client - mock_ctrl and 
   cfg = request.param
   config_dir = tempfile.mkdtemp()
   config_file = os.path.join(config_dir, 'house.json')
-  status_dir = os.path.join(config_dir,'config', 'status')
-  os.makedirs(status_dir)
+  status_dir = amplipi.ctrl.USER_CACHE_DIR
+  os.makedirs(status_dir, exist_ok=True)
   with open(os.path.join(status_dir, 'latest_release'), 'w', encoding='utf-8') as version_file:
     version_file.write('0.1.8\n')
   with open(config_file, 'w') as cfg_file:

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -224,6 +224,7 @@ def test_open_api_yamlfile(client):
   """ Check if the openapi yaml doc is available """
   rv = client.get('/openapi.yaml')
   assert rv.status_code == HTTPStatus.OK
+
 # To reduce the amount of boilerplate we use test parameters.
 # Examples: https://docs.pytest.org/en/stable/example/parametrize.html#paramexamples
 
@@ -234,7 +235,7 @@ def test_info(client):
   assert rv.status_code == HTTPStatus.OK
   jrv = rv.json()
   for val in jrv.values():
-    assert val is not None
+    assert val is not None, "Unpopulated info field, expected value got 'None'"
     if isinstance(val, str):
       assert val.lower() != 'unknown', "Unpopulated info field"
 


### PR DESCRIPTION
We need to add more information to make development, production, and release handling easier
- [x] git hash and branch (embedded in version with deploy script) needed for normal releases? We can use/link to the version tag on GH 
- [x] firmware hash - Read by sw at init time
- [x] firmware version - Read by sw at init time
- [x] new release available - crontab script updates file with latest realease (daily)
    - Get the latest release with `curl -s https://api.github.com/repos/micro-nova/AmpliPi/releases/latest | jq -r ".tag_name"`
    - Requires json parser, jq
- [x] offline - crontab script updates file with online/offline status every 2min (1.1.1.1)
    -  Something like `nc -w 5 -z 1.1.1.1 53  >/dev/null 2>&1 && echo Online || echo Offline`

In another PR these will be integrated into the web ui
Reminder
- Add link to version tag in ui