### PR TITLE
Small fixes

### DIFF
--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -77,7 +77,7 @@ class fields(SimpleNamespace):
 class fields_w_default(SimpleNamespace):
   """ AmpliPi's field types that need a default value
 
-  These are needed because there is ambiguity where and optional field has a default value
+  These are needed because there is ambiguity where an optional field has a default value
   """
   # TODO: less duplication
   SourceId = Field(default=0, ge=0, le=3, description='id of the connected source')
@@ -280,7 +280,7 @@ class ZoneUpdate(BaseUpdate):
             'source-id': 3
           }
         },
-        'Increase Volume': {
+        'Change Volume': {
           'value': {
             'vol': pcnt2Vol(0.44)
           }
@@ -328,7 +328,7 @@ class MultiZoneUpdate(BaseModel):
     }
 
 class Group(Base):
-  """ A group of zones that can share the same audio input and be controlled as a group ie. Updstairs.
+  """ A group of zones that can share the same audio input and be controlled as a group ie. Upstairs.
 
   Volume, mute, and source_id fields are aggregates of the member zones."""
   source_id: Optional[int] = fields.SourceId

--- a/config/boot_config.txt
+++ b/config/boot_config.txt
@@ -43,7 +43,7 @@
 #arm_freq=800
 
 # Uncomment some or all of these to enable the optional hardware interfaces
-dtparam=i2c_arm=on, i2c_arm_baudrate=50000
+dtparam=i2c_arm=on,i2c_arm_baudrate=100000
 dtparam=i2s=on
 dtparam=spi=on
 


### PR DESCRIPTION
After checking out some old branches to clean up, I found a few small fixes that haven't found there way into any PRs. It's just a couple typos, the boot.txt's i2c baudrate is set properly (the formatting was wrong so what appeared to be set was in fact not being used), and the only thing that's potentially controversial @linknum23 is I think the 'Increase Volume' API example should be called 'Change Volume'.