### PR TITLE
Only log to RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AmpliPi Software Releases
 
+## 0.1.X Upcoming
+* Web App
+  * Add link for text log
+* API
+* Streams
+* Storage
+  * Only log to RAM, drastically reducing disk writes
+  * Use ram disks for temporary stream configration and metadata storage
+
 ## 0.1.8
 * Web App
   * Add consistent play/pause/prev/next controls

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -281,6 +281,8 @@ async def get_image(ctrl: Api = Depends(get_ctrl), sid: int = params.SourceID, h
     uri = uri.replace('static/', STATIC_DIR + '/')
     uri = uri.replace('rca_inputs.svg', 'rca_inputs.jpg')  # pillow can't handle svg files for our use case
 
+  # TODO: writing images to /tmp adds file system pressure
+  # we should write only a couple to RAM disk instead and manage a small amount of garbage collection
   img_tmp = f'/tmp/{os.path.basename(uri)}'
   img_tmp_jpg = f'{img_tmp}-{height}x{width}.jpg'
 

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -261,7 +261,7 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
   tasks += print_progress([Task('get latest debian packages', 'sudo apt-get update --allow-releaseinfo-change'.split()).run()])
 
   # Upgrade current packages
-  print_progress([Task("upgrading debian paackages, this will take 10+ minutes", success=True)])
+  print_progress([Task("upgrading debian packages, this will take 10+ minutes", success=True)])
   tasks += print_progress([Task('upgrade debian packages', 'sudo apt-get upgrade --assume-yes'.split()).run()])
 
   # organize stuff to install

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -39,7 +39,7 @@ _os_deps: Dict[str, Dict[str, Any]] = {
       'sudo systemctl stop rsyslog.service',
       'sudo systemctl disable rsyslog.service',
       # reconfigure journald to only log to RAM
-      'echo -e "[Journal]\nStorage=volatile\nRuntimeMaxUse=64M\n" | sudo tee /etc/systemd/journald.conf',
+      r'echo -e "[Journal]\nStorage=volatile\nRuntimeMaxUse=64M\nForwardToConsole=no\nForwardToWall=no\n" | sudo tee /etc/systemd/journald.conf',
       'sudo systemctl restart systemd-journald.service',
       # delete some old logs
       'sudo journalctl --rotate',
@@ -255,7 +255,7 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
     with open(sh_loc, 'a') as sh:
       for scrap in script:
         sh.write(scrap + '\n')
-    shargs = f'sh {sh_loc}'.split()
+    shargs = f'bash {sh_loc}'.split()
     clean = f'rm {sh_loc}'.split()
     tasks += print_progress([Task(f'run {dep} install script', args=shargs, wd=env['base_dir']).run()])
     tasks += print_progress([Task(f'remove {dep} temporary script', args=clean, wd=env['base_dir']).run()])

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -24,25 +24,56 @@ RSYSLOG_CFG = """# /etc/rsyslog.conf configuration file for rsyslog
 # Created by AmpliPi installer
 #  Drastically limits logging to any local files while maintaining
 # remote logging capabilities.
+#
+# For more information install rsyslog-doc and see
+# /usr/share/doc/rsyslog-doc/html/configuration/index.html
+
+
+#################
+#### MODULES ####
+#################
 
 module(load="imuxsock") # provides support for local system logging
 module(load="imklog")   # provides kernel logging support
 
-# Use traditional timestamp format
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+
+#
+# Use traditional timestamp format.
+# To enable high precision timestamps, comment out the following line.
+#
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
+#
 # Set the default permissions for all log files.
+#
 $FileOwner root
 $FileGroup adm
 $FileCreateMode 0640
 $DirCreateMode 0755
 $Umask 0022
 
+#
 # Where to place spool and state files
+#
 $WorkDirectory /var/spool/rsyslog
 
+#
 # Include all config files in /etc/rsyslog.d/
+#
 $IncludeConfig /etc/rsyslog.d/*.conf
+
+
+###############
+#### RULES ####
+###############
+
+# Emergencies are sent to everybody logged in.
+#
+*.emerg                         :omusrmsg:*
+
 """
 
 _os_deps: Dict[str, Dict[str, Any]] = {

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -191,6 +191,9 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
   # Repository 'http://raspbian.raspberrypi.org/raspbian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
   tasks += print_progress([Task('get latest debian packages', 'sudo apt-get update --allow-releaseinfo-change'.split()).run()])
 
+  # Upgrade current packages
+  tasks += print_progress([Task('upgrade debian packages', 'sudo apt-get upgrade'.split()).run()])
+
   # organize stuff to install
   packages = set()
   files = []

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -192,6 +192,7 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
   tasks += print_progress([Task('get latest debian packages', 'sudo apt-get update --allow-releaseinfo-change'.split()).run()])
 
   # Upgrade current packages
+  print_progress([Task("upgrading debian paackages, this will take 10+ minutes", success=True)])
   tasks += print_progress([Task('upgrade debian packages', 'sudo apt-get upgrade --assume-yes'.split()).run()])
 
   # organize stuff to install

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -94,7 +94,7 @@ _os_deps: Dict[str, Dict[str, Any]] = {
   'logging' : {
     'script' : [
       'echo "reconfiguring secondary logging utility rsyslog to only allow remote logging"',
-      f"echo '{RSYSLOG_CFG}' | sudo tee /etc/syslog.conf",
+      f"echo '{RSYSLOG_CFG}' | sudo tee /etc/rsyslog.conf",
       'sudo systemctl enable rsyslog.service', # just in case it was disabled...
       'sudo systemctl restart rsyslog.service',
 

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -44,7 +44,7 @@ _os_deps: Dict[str, Dict[str, Any]] = {
       # delete some old logs
       'sudo journalctl --rotate',
       'sudo journalctl --vacuum-time=10m',
-      'sudo rm /var/log/daemon* /var/log/syslog* /var/log/messages* /var/log/user*',
+      'sudo rm /var/log/daemon* /var/log/syslog* /var/log/messages* /var/log/user* || echo ok',
     ]
   },
   # streams
@@ -192,7 +192,7 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
   tasks += print_progress([Task('get latest debian packages', 'sudo apt-get update --allow-releaseinfo-change'.split()).run()])
 
   # Upgrade current packages
-  tasks += print_progress([Task('upgrade debian packages', 'sudo apt-get upgrade'.split()).run()])
+  tasks += print_progress([Task('upgrade debian packages', 'sudo apt-get upgrade --assume-yes'.split()).run()])
 
   # organize stuff to install
   packages = set()

--- a/web/templates/index.html.j2
+++ b/web/templates/index.html.j2
@@ -357,6 +357,7 @@
       <a href="https://www.github.com/micro-nova/AmpliPi" target="_blank" rel="noopener noreferrer">GitHub</a> |
       <a href="https://amplipi.discourse.group" target="_blank" rel="noopener noreferrer">Community</a> |
       <a href="https://github.com/micro-nova/AmpliPi/blob/master/COPYING" target="_blank" rel="noopener noreferrer">License</a></span>
+      <a href="/entries" onclick="javascript:event.target.port=5001" target="_blank" rel="noopener noreferrer">Logs</a></span>
     </div>
   </div>
 </div>

--- a/web/templates/index.html.j2
+++ b/web/templates/index.html.j2
@@ -356,8 +356,8 @@
       <span><a href="/doc" target="_blank" rel="noopener noreferrer">API</a> |
       <a href="https://www.github.com/micro-nova/AmpliPi" target="_blank" rel="noopener noreferrer">GitHub</a> |
       <a href="https://amplipi.discourse.group" target="_blank" rel="noopener noreferrer">Community</a> |
-      <a href="https://github.com/micro-nova/AmpliPi/blob/master/COPYING" target="_blank" rel="noopener noreferrer">License</a></span>
-      <a href="/entries" onclick="javascript:event.target.port=5001" target="_blank" rel="noopener noreferrer">Logs</a></span>
+      <a href="https://github.com/micro-nova/AmpliPi/blob/master/COPYING" target="_blank" rel="noopener noreferrer">License</a></span> |
+      <a href="/entries" onclick="javascript:event.target.port=19531" target="_blank" download="amplipi_log.txt" rel="noopener noreferrer">Logs</a></span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Significantly reduce logging to disk and make AmpliPi log almost exclusively to RAM. 

Some other additions:
- upgrade apt packages
- add text log view