### PR TITLE
Disable and mute

### DIFF
--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -101,7 +101,7 @@ def unused_groups(ctrl: Api, src: int) -> Dict[int, str]:
 def unused_zones(ctrl: Api, src: int) -> Dict[int, str]:
   """ Get zones that are not conencted to src """
   zones = ctrl.status.zones
-  return {z.id : z.name for z in zones if z.source_id != src and z.id is not None}
+  return {z.id : z.name for z in zones if z.source_id != src and z.id is not None and not z.disabled}
 
 def ungrouped_zones(ctrl: Api, src: int) -> List[models.Zone]:
   """ Get zones that are connected to src, but don't belong to a full group """

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -522,6 +522,11 @@ class Api:
         zone.name = name
         zone.disabled = disabled
 
+        # any disabled zone should not be able to play anything, mute it to be sure
+        if zone.disabled and not mute:
+          mute = True
+          update_mutes = True
+
         # update the zone's associated source
         sid = utils.parse_int(source_id, [0, 1, 2, 3])
         zones = self.status.zones

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -330,7 +330,7 @@ def test_get_zone(client, zid):
   assert s['name'] == jrv['name']
 
 @pytest.mark.parametrize('zid', base_zone_ids())
-def test_patch_zone(client, zid):
+def test_patch_zone_rename(client, zid):
   """ Try changing a zones name """
   rv = client.patch('/api/zones/{}'.format(zid), json={'name': 'patched-name'})
   assert rv.status_code == HTTPStatus.OK
@@ -338,6 +338,30 @@ def test_patch_zone(client, zid):
   s = find(jrv['zones'], zid)
   assert s is not None
   assert s['name'] == 'patched-name'
+
+@pytest.mark.parametrize('zid', base_zone_ids())
+def test_patch_zone_mute_disable(client, zid):
+  """ Unmute then disable a zone """
+  rv = client.patch('/api/zones/{}'.format(zid), json={'mute': False, 'vol_f': 0.5})
+  assert rv.status_code == HTTPStatus.OK
+  jrv = rv.json()
+  s = find(jrv['zones'], zid)
+  assert s is not None
+  assert s['mute'] == False
+  assert s['vol_f'] == 0.5
+  rv = client.patch('/api/zones/{}'.format(zid), json={'disabled': True})
+  assert rv.status_code == HTTPStatus.OK
+  jrv = rv.json()
+  s = find(jrv['zones'], zid)
+  assert s is not None
+  assert s['disabled'] == True
+  assert s['mute'] == True
+  rv = client.patch('/api/zones/{}'.format(zid), json={'mute': False})
+  assert rv.status_code == HTTPStatus.OK
+  jrv = rv.json()
+  s = find(jrv['zones'], zid)
+  assert s is not None
+  assert s['mute'] == True # a disabled zone overrides/forces mute
 
 @pytest.mark.parametrize('sid', base_source_ids())
 def test_patch_zones(client, sid):


### PR DESCRIPTION
As discussed in #384 a disabled zone should be muted. This adds a fix for this and a test to verify it.
It also adds a related fix to remove a disabled zone from an app drop down.