### PR TITLE
Config validation and loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # AmpliPi Software Releases
 
 ## 0.1.X Upcoming
+* Streams
+  * Robustify config loading to handle missing streams
+  * Simplify stream serialization
 
 ## 0.1.9
 * Web App

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -363,10 +363,9 @@ class Api:
     self.status.info.online = self._online_cache.get(throttled)
     self.status.info.latest_release = self._latest_release_cache.get(throttled)
 
-  def get_state(self) -> models.Status:
-    """ get the system state """
-    # update the state with the latest stream info
-    # TODO: figure out how to cache stream info
+  def _sync_stream_info(self) -> None:
+    """Synchronize the stream list to the stream status"""
+    # TODO: figure out how to cache stream info, since it only needs to happen when a stream is added/updated
     optional_fields = ['station', 'user', 'password', 'url', 'logo', 'freq', 'token', 'client_id'] # optional configuration fields
     streams = []
     for sid, stream_inst in self.streams.items():
@@ -379,7 +378,11 @@ class Api:
           stream.__dict__[field] = stream_inst.__dict__[field]
       streams.append(stream)
     self.status.streams = streams
+
+  def get_state(self) -> models.Status:
+    """ get the system state """
     self._update_sys_info()
+    self._sync_stream_info()
     # update source's info
     # TODO: stream/source info should be updated in a background thread
     for src in self.status.sources:

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -376,14 +376,13 @@ class Api:
   def _sync_stream_info(self) -> None:
     """Synchronize the stream list to the stream status"""
     # TODO: figure out how to cache stream info, since it only needs to happen when a stream is added/updated
-    optional_fields = ['station', 'user', 'password', 'url', 'logo', 'freq', 'token', 'client_id'] # optional configuration fields
     streams = []
     for sid, stream_inst in self.streams.items():
       # TODO: this functionality should be in the unimplemented streams base class
       # convert the stream instance info to stream data (serialize its current configuration)
       st_type = type(stream_inst).__name__.lower()
       stream = models.Stream(id=sid, name=stream_inst.name, type=st_type)
-      for field in optional_fields:
+      for field in models.optional_stream_fields():
         if field in stream_inst.__dict__:
           stream.__dict__[field] = stream_inst.__dict__[field]
       streams.append(stream)

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -243,15 +243,14 @@ class Api:
     self.streams: Dict[int, amplipi.streams.AnyStream] = {}
     failed_streams: List[int] = []
     for stream in self.status.streams:
+      assert stream.id is not None
       if stream.id:
         try:
           self.streams[stream.id] = amplipi.streams.build_stream(stream, self._mock_streams)
         except Exception as exc:
           print(f"Failed to create '{stream.name}' stream: {exc}")
           failed_streams.append(stream.id)
-    # only keep the successful streams, this fixes a common problem of loading a stream that doesn't exist in the current developement
-    # [:] does an in-place modification to the list suggested by https://stackoverflow.com/a/1208792/1110730
-    self.status.streams[:] = [s for s in self.status.streams if s.id not in failed_streams]
+    self._sync_stream_info() # need to update the status with the new streams
 
     # configure all sources so that they are in a known state
     for src in self.status.sources:

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -255,8 +255,19 @@ class Api:
     # configure all sources so that they are in a known state
     for src in self.status.sources:
       if src.id is not None:
-        update = models.SourceUpdate(input=src.input)
-        self.set_source(src.id, update, force_update=True, internal=True)
+        try:
+          update = models.SourceUpdate(input=src.input)
+          self.set_source(src.id, update, force_update=True, internal=True)
+        except Exception as e:
+          print(f'Error configuring source {src.id}: {e}')
+          print(f'defaulting source {src.id} to an empty input')
+          update = models.SourceUpdate(input='')
+          try:
+            self.set_source(src.id, update, force_update=True, internal=True)
+          except Exception as e2:
+            print(f'Error configuring source {src.id}: {e2}')
+            print(f'Source {src.id} left uninitialized')
+
     # configure all of the zones so that they are in a known state
     #   we mute all zones on startup to keep audio from playing immediately at startup
     for zone in self.status.zones:

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -20,7 +20,8 @@ Encourages reuse of datastructures across AmpliPi
 """
 
 # type handling, fastapi leverages type checking for performance and easy docs
-from typing import List, Dict, Optional, Union
+from functools import lru_cache
+from typing import List, Dict, Optional, Union, Set
 from types import SimpleNamespace
 from enum import Enum
 
@@ -595,6 +596,12 @@ class Stream(Base):
         },
       }
     }
+
+@lru_cache(1)
+def optional_stream_fields() -> Set:
+  """ Extra fields that can be preset in a stream """
+  model = Stream(id=0, name='', type='fake').dict()
+  return { k for k, v in model.items() if v is None }
 
 class StreamUpdate(BaseUpdate):
   """ Reconfiguration of a Stream """

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -32,9 +32,10 @@ TEST_CONFIG['groups'] = [
   {"id": 102, "name": "Group 3", "zones": [5],    "source_id": 0, "mute": True, "vol_f": amplipi.models.MIN_VOL_F},
 ]
 AP_STREAM_ID = 1000
+P_STREAM_ID = 1001
 TEST_CONFIG['streams'] = [
   {"id": AP_STREAM_ID, "name": "AmpliPi", "type": "shairport"},
-  {"id": 1001, "name": "Radio Station, needs user/pass/station-id", "type": "pandora", "user": "change@me.com", "password": "CHANGEME", "station": "CHANGEME"},
+  {"id": P_STREAM_ID, "name": "Radio Station, needs user/pass/station-id", "type": "pandora", "user": "change@me.com", "password": "CHANGEME", "station": "CHANGEME"},
   {"id": 1002, "name": "AmpliPi", "type": "spotify"},
   {"id": 1003, "name": "Groove Salad", "type": "internetradio", "url": "http://ice6.somafm.com/groovesalad-32-aac", "logo": "https://somafm.com/img3/groovesalad-400.jpg"},
   {"id": 1004, "name": "AmpliPi", "type": "dlna"},
@@ -239,11 +240,13 @@ def test_load_null_config(client):
 def test_load_multi_config(client):
   """ Load multiple configurations """
   # create a test config with a connected stream
-  sinput=f'stream={AP_STREAM_ID}'
+  sinputs = [f'stream={AP_STREAM_ID}', f'stream={P_STREAM_ID}']
   stream_test_config = deepcopy(client.original_config)
   if 'streams' in stream_test_config:
-    stream_test_config['sources'][0]['input'] = sinput
+    stream_test_config['sources'][0]['input'] = sinputs[0]
+    stream_test_config['sources'][1]['input'] = sinputs[1]
     assert stream_test_config['streams'][0]['id'] == AP_STREAM_ID, f"Test config expects a stream with id={AP_STREAM_ID}"
+    assert stream_test_config['streams'][1]['id'] == P_STREAM_ID, f"Test config expects a stream with id={P_STREAM_ID}"
   # load a barebones config
   rv = client.post('/api/load', json={'config': amplipi.models.Status().dict()})
   assert rv.status_code == HTTPStatus.OK

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -247,11 +247,28 @@ def test_load_multi_config(client):
     multi_stream_cfg['sources'][1]['input'] = sinputs[1]
     assert multi_stream_cfg['streams'][0]['id'] == AP_STREAM_ID, f"Test config expects a stream with id={AP_STREAM_ID}"
     assert multi_stream_cfg['streams'][1]['id'] == P_STREAM_ID, f"Test config expects a stream with id={P_STREAM_ID}"
-  # create a simple config with a single stream connected
+  # create a simple config with a single stream connected, with metadata representing raw config load
   single_stream_cfg = amplipi.models.Status().dict()
-  single_stream_cfg['sources'][0]['input'] = f'stream=2000'
+  single_stream_cfg['sources'][0] = {
+    "id": 0,
+    "name": "Input 1",
+    "input": "stream=2000",
+    "info": {
+      "name": "Groove Salad - internet radio",
+      "state": "playing",
+      "artist": "Liam Thomas",
+      "track": "With your touch",
+      "station": "Groove Salad [SomaFM]",
+      "img_url": "https://somafm.com/img3/groovesalad-400.jpg",
+      "supported_cmds": [
+        "play",
+        "stop"
+      ]
+    }
+  }
   single_stream_cfg['streams'] = [
-    {"id": 2000, "name": "SimpleAmpliPi", "type": "shairport"},
+    {"id": 2000, 'name': 'Groove Salad', "type": "internetradio",
+     "url": "http://ice6.somafm.com/groovesalad-32-aac", "logo": "https://somafm.com/img3/groovesalad-400.jpg"}
   ]
   # create a barebones config with no streams
   bare_cfg = deepcopy(amplipi.models.Status().dict())


### PR DESCRIPTION
Minor changes to robustify config and stream serialization
- Minimize stream serialization, this only happens on a stream change now.
- Use serialization  changes to simplify the config init code as well
- Add recovery logic when stream used is not available
- Upgrade the config validation tests to catch any config loading errors

~~These changes were originally made to fix a bug we were seeing for configuration load problems,. Oddly we have not been able to reproduce the configuration load problems. That said this code simplifies state changes enough that we think it still makes sense to include it.~~ 
The bug was due to loading an unsupported stream that was connected to a source, This was fixed.