### PR TITLE
Remove desktop tests and make more configuration AmpliPi only

### DIFF
--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -92,6 +92,7 @@ _os_deps: Dict[str, Dict[str, Any]] = {
   'web' : {
   },
   'logging' : {
+    'amplipi-only' : True,
     'script' : [
       'echo "reconfiguring secondary logging utility rsyslog to only allow remote logging"',
       f"echo '{RSYSLOG_CFG}' | sudo tee /etc/rsyslog.conf",
@@ -281,6 +282,8 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
   files = []
   scripts: Dict[str, List[str]] = {}
   for dep in deps:
+    if dep.get('amplipi-only', False) and not env['is_amplipi']:
+      continue
     install_steps = _os_deps[dep]
     if 'copy' in install_steps:
       files += install_steps['copy']

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -268,7 +268,11 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
     progress(tasks)
     return tasks
   tasks = []
-  # TODO: add extra apt repos
+  tasks += fix_file_props(env, progress)
+  if env['is_amplipi']:
+    tasks += add_tests(env, progress)
+  print_progress(tasks)
+
   # find latest apt packages. --allow-releaseinfo-change automatically allows the following change:
   # Repository 'http://raspbian.raspberrypi.org/raspbian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
   tasks += print_progress([Task('get latest debian packages', 'sudo apt-get update --allow-releaseinfo-change'.split()).run()])
@@ -851,11 +855,6 @@ def install(os_deps=True, python_deps=True, web=True, restart_updater=False,
     tasks[0].output = str(env)
     tasks[0].success = True
   progress(tasks)
-  if failed():
-    return False
-  tasks += fix_file_props(env, progress)
-  if env['is_amplipi']:
-    tasks += add_tests(env, progress)
   if failed():
     return False
   if os_deps:

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -826,7 +826,7 @@ def add_tests(env, progress) -> List[Task]:
   # create the ~/tests directory if it doesn't already exist
   directory = pathlib.Path.home().joinpath('Desktop', 'tests')
   tasks += _create_dir(str(directory))
-
+  tasks += [Task('Remove old tests', [f'rm {str(directory)}/*'], shell=True).run()]
   for test in tests:
     tasks += [_add_desktop_icon(env, directory, test[0], test[1])]
   progress(tasks)


### PR DESCRIPTION
This cleans up some of our configuration script used to install development versions and updates on AmpliPis and development debian-based Linux machines.

- [x] Remove old (Desktop accessible) tests on an install
  - This may have some implications for our actual test setups if there are some uncommited tests.
  - A backup of tests should be made on those units. 
- [x] Add a simple tag to distinguish some of the things installed as amplipi-only?
  - This should avoid breaking development machines (Sorry @Lohrer!)
- [ ] Test this in conjunction with removing a test
- [x] Move the desktop icon creation into os-deps sub task