### PR TITLE
Make mono to stereo conversion automatic (fixes fmradio)

### DIFF
--- a/config/asound.conf
+++ b/config/asound.conf
@@ -93,7 +93,7 @@ pcm.dmixer {
 pcm.ch1 {
     type                plug
     slave.pcm {
-        type            route
+        type            plug
         slave.pcm       "dmixer"
         slave.channels  8
         ttable.0.6      0.64
@@ -104,7 +104,7 @@ pcm.ch1 {
 pcm.ch2 {
     type                plug
     slave.pcm {
-        type            route
+        type            plug
         slave.pcm       "dmixer"
         slave.channels  8
         ttable.0.0      0.64
@@ -115,7 +115,7 @@ pcm.ch2 {
 pcm.ch3 {
     type                plug
     slave.pcm {
-        type            route
+        type            plug
         slave.pcm       "dmixer"
         slave.channels  8
         ttable.0.4      0.64

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -107,11 +107,34 @@ pcm.ch3 {
     ttable.1.5      0.64
 }
 
-# Duplicate a mono stream to stereo for testing, since
-# `speaker-test` only plays one mono output at a time.
+# Duplicate mono streams to stereo
+# - `speaker-test` only plays one mono output at a time
+# - fmradio.py only proceses mono and alsa cannot automatically map
+#   to stereo for syntetic outputs ch1, ch2, and ch3
 pcm.ch0m2s {
     type            route
     slave.pcm       "ch0"
+    slave.channels  2
+    ttable.0.0      1
+    ttable.0.1      1
+}
+pcm.ch1m2s {
+    type            route
+    slave.pcm       "ch1"
+    slave.channels  2
+    ttable.0.0      1
+    ttable.0.1      1
+}
+pcm.ch2m2s {
+    type            route
+    slave.pcm       "ch2"
+    slave.channels  2
+    ttable.0.0      1
+    ttable.0.1      1
+}
+pcm.ch3m2s {
+    type            route
+    slave.pcm       "ch3"
     slave.channels  2
     ttable.0.0      1
     ttable.0.1      1

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -85,57 +85,41 @@ pcm.dmixer {
 #   Attenuate to 28% to avoid amplifier clipping
 #   For now leaving at 64% to maximize SNR before the amplifiers, and to leave
 #   some headroom for per-zone attenuation settings
+# A 2 channel intermediate PCM layer is added to each plug output below
+#   this enables automatic mono -> stereo conversions since
+#   ALSA does not understand how to convert mono to 8 channels.
+#   In that case the mono input would be mapped to the first (left) channel,
+#   with nothing playing out the right channel.
 pcm.ch1 {
-    type            plug
-    slave.pcm       "dmixer"
-    slave.channels  8
-    ttable.0.6      0.64
-    ttable.1.7      0.64
+    type                plug
+    slave.pcm {
+        type            route
+        slave.pcm       "dmixer"
+        slave.channels  8
+        ttable.0.6      0.64
+        ttable.1.7      0.64
+    }
+    slave.channels      2
 }
 pcm.ch2 {
-    type            plug
-    slave.pcm       "dmixer"
-    slave.channels  8
-    ttable.0.0      0.64
-    ttable.1.1      0.64
+    type                plug
+    slave.pcm {
+        type            route
+        slave.pcm       "dmixer"
+        slave.channels  8
+        ttable.0.0      0.64
+        ttable.1.1      0.64
+    }
+    slave.channels      2
 }
 pcm.ch3 {
-    type            plug
-    slave.pcm       "dmixer"
-    slave.channels  8
-    ttable.0.4      0.64
-    ttable.1.5      0.64
-}
-
-# Duplicate mono streams to stereo
-# - `speaker-test` only plays one mono output at a time
-# - fmradio.py only proceses mono and alsa cannot automatically map
-#   to stereo for syntetic outputs ch1, ch2, and ch3
-pcm.ch0m2s {
-    type            route
-    slave.pcm       "ch0"
-    slave.channels  2
-    ttable.0.0      1
-    ttable.0.1      1
-}
-pcm.ch1m2s {
-    type            route
-    slave.pcm       "ch1"
-    slave.channels  2
-    ttable.0.0      1
-    ttable.0.1      1
-}
-pcm.ch2m2s {
-    type            route
-    slave.pcm       "ch2"
-    slave.channels  2
-    ttable.0.0      1
-    ttable.0.1      1
-}
-pcm.ch3m2s {
-    type            route
-    slave.pcm       "ch3"
-    slave.channels  2
-    ttable.0.0      1
-    ttable.0.1      1
+    type                plug
+    slave.pcm {
+        type            route
+        slave.pcm       "dmixer"
+        slave.channels  8
+        ttable.0.4      0.64
+        ttable.1.5      0.64
+    }
+    slave.channels      2
 }

--- a/streams/fmradio.py
+++ b/streams/fmradio.py
@@ -62,8 +62,15 @@ def main():
 
   update = False
 
+  # configure RTLSDR and and process FM radio signal
+  #  NOTE: FM decoding is typically done using -M wbfm which implies "-M fm -s 170k -A fast -r 32k -l 0 -E deemp" which sounds ok, but has a lot of noise
+  #  The additional parameters specified below sound much better in our experience
   rtlfm_args = f'rtl_fm -M fm -f {freq}M -s 171k -A std -p 0 -l 0 -E deemp -g 20 -F 9'.split()
+  # metadata processing using redsea
   redsea_args = ['redsea', '-u', '-p', '--feed-through']
+  # alsa output stage
+  # - convert mono output -> stereo using alsa routes chXm2s
+  # - normally mono conversion happens automatically but only the left channel was playing for ch1, ch2, and ch3
   aplay_args = ['aplay', '-r', '171000', '-f', 'S16_LE', '--device', f'{args.output}m2s']
 
   rtlfm_proc = subprocess.Popen(args=rtlfm_args, bufsize=1024, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/streams/fmradio.py
+++ b/streams/fmradio.py
@@ -68,9 +68,9 @@ def main():
   rtlfm_args = f'rtl_fm -M fm -f {freq}M -s 171k -A std -p 0 -l 0 -E deemp -g 20 -F 9'.split()
   # metadata processing using redsea
   redsea_args = ['redsea', '-u', '-p', '--feed-through']
-  # alsa output stage
-  # - convert mono output -> stereo using alsa routes chXm2s
-  # - normally mono conversion happens automatically but only the left channel was playing for ch1, ch2, and ch3
+  # ALSA output stage
+  # - rtl_fm output is mono
+  # - mono to stereo conversion happens automatically via ALSA plug module
   aplay_args = ['aplay', '-r', '171000', '-f', 'S16_LE', '--device', f'{args.output}']
 
   rtlfm_proc = subprocess.Popen(args=rtlfm_args, bufsize=1024, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/streams/fmradio.py
+++ b/streams/fmradio.py
@@ -71,7 +71,7 @@ def main():
   # alsa output stage
   # - convert mono output -> stereo using alsa routes chXm2s
   # - normally mono conversion happens automatically but only the left channel was playing for ch1, ch2, and ch3
-  aplay_args = ['aplay', '-r', '171000', '-f', 'S16_LE', '--device', f'{args.output}m2s']
+  aplay_args = ['aplay', '-r', '171000', '-f', 'S16_LE', '--device', f'{args.output}']
 
   rtlfm_proc = subprocess.Popen(args=rtlfm_args, bufsize=1024, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   redsea_proc = subprocess.Popen(args=redsea_args, bufsize=1024, stdin=rtlfm_proc.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/streams/fmradio.py
+++ b/streams/fmradio.py
@@ -64,7 +64,7 @@ def main():
 
   rtlfm_args = f'rtl_fm -M fm -f {freq}M -s 171k -A std -p 0 -l 0 -E deemp -g 20 -F 9'.split()
   redsea_args = ['redsea', '-u', '-p', '--feed-through']
-  aplay_args = ['aplay', '-r', '171000', '-f', 'S16_LE', '--device', '{}'.format(args.output)]
+  aplay_args = ['aplay', '-r', '171000', '-f', 'S16_LE', '--device', f'{args.output}m2s']
 
   rtlfm_proc = subprocess.Popen(args=rtlfm_args, bufsize=1024, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   redsea_proc = subprocess.Popen(args=redsea_args, bufsize=1024, stdin=rtlfm_proc.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Closes #454.

To test a nearby radio station is 91.7, verify that stereo audio is output on each source.