### PR TITLE
fix: correct radio-browser.info server selection

### DIFF
--- a/web2/src/pages/Settings/Streams/StreamModal/StreamModal.jsx
+++ b/web2/src/pages/Settings/Streams/StreamModal/StreamModal.jsx
@@ -92,7 +92,7 @@ const InternetRadioSearch = ({ onChange }) => {
       fetch("http://all.api.radio-browser.info/json/servers").then((res) =>
         res.json().then(async (s) => {
           for (const i of s) {
-            const res = await fetch(i.ip)
+            const res = await fetch('https://' + i.name)
             if (res.ok && res.status === 200) {
               setHost(i.name)
               break


### PR DESCRIPTION
This PR is a small fix for the radio-browser.info server selection dialog. Without it, the browser attempts to fetch the IP address as if it were a relative path on the host. I've also changed this to use the `name` value so we can take advantage of TLS.

I admittedly haven't tested this :sweat_smile: 