### PR TITLE
Add password functionality to the updater interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,9 @@ dmypy.json
 # vscode
 *.code-workspace
 
+# vi
+*.swp
+
 # Poetry
 poetry.lock
 

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -811,6 +811,7 @@ class Info(BaseModel):
   mock_streams: bool = Field(default=False, description='Are streams being faked? Used for testing.')
   online: bool = Field(default=False, description='can the system connect to the internet?')
   latest_release: str = Field(default='unknown', description='Latest software release available from GitHub')
+  admin_password_hash: Optional[str] = Field(description='An optional Argon2id hash of a password for the update interface. Recommended params: m=19456,t=2,p=1')
   fw: List[FirmwareInfo] = Field(default=[], description='firmware information for each connected controller or expansion unit')
 
   class Config:
@@ -824,6 +825,7 @@ class Info(BaseModel):
             'mock_streams': False,
             'online': True,
             'latest_release': '0.1.8',
+            'admin_password_hash': '$argon2id$v=19$m=19456,t=2,p=1$bWljcm9ub3Zh$e9tlH+uUmDuNk4kXdGrX9NnBLk7uHjJMs7lmZ6EEoBg',
             'fw': [
               {
                 "version": "1.6",

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -811,7 +811,6 @@ class Info(BaseModel):
   mock_streams: bool = Field(default=False, description='Are streams being faked? Used for testing.')
   online: bool = Field(default=False, description='can the system connect to the internet?')
   latest_release: str = Field(default='unknown', description='Latest software release available from GitHub')
-  admin_password_hash: Optional[str] = Field(description='An optional Argon2id hash of a password for the update interface. Recommended params: m=19456,t=2,p=1')
   fw: List[FirmwareInfo] = Field(default=[], description='firmware information for each connected controller or expansion unit')
 
   class Config:
@@ -825,7 +824,6 @@ class Info(BaseModel):
             'mock_streams': False,
             'online': True,
             'latest_release': '0.1.8',
-            'admin_password_hash': '$argon2id$v=19$m=19456,t=2,p=1$bWljcm9ub3Zh$e9tlH+uUmDuNk4kXdGrX9NnBLk7uHjJMs7lmZ6EEoBg',
             'fw': [
               {
                 "version": "1.6",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 adafruit-circuitpython-rgb-display==3.11.0
 aiofiles==23.1.0
+argon2-cffi==21.3.0
 bluezero==0.7.1
 dasbus==1.7
 dbus-python==1.3.2


### PR DESCRIPTION
This PR adds simple HTTP Basic authentication for the updater. It does not attempt to document this feature fully, nor present an functionality in the frontend to set this password.  This ought to resolve #477 .

The trick to this PR wasn't in the implementation of the authentication itself, but only optionally presenting it in the setup requesting it (ie, having a `admin_password_hash` configured in `house.json`'s `info` object.) I will self-review these potentially slippery parts of the code and would appreciate an extra set of eyes on it.

I chose to hash this password using [Argon2id](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id). This might seem like overkill, except we're storing the equivalent of a root password on these network connected devices; we should expect it to have strong resistance to attack. (Now the weak point is (the lack of) HTTPS :joy: )  The parameters were a smidge more tricky; the compromise here involves making a hash that's both light enough for a single iteration on a Raspberry Pi Compute 3 module, yet heavy enough to resist brute force on lots of hardware. The parameters m=19456 (19 MiB), t=2, p=1 are presently recommended as a minimum and take about 220ms on our current hardware, the upper end of what we ought to tolerate in response times; this is what I've recommended in the config documentation and tested with.

self-review in 3, 2, 1...