### PR TITLE
feat: initial boot partitioning script

### DIFF
--- a/scripts/first_boot_partitioning
+++ b/scripts/first_boot_partitioning
@@ -1,0 +1,78 @@
+#!/bin/sh
+# create a partition scheme on first bootup that looks like this:
+# - boot partition, original size
+# - system partition #1, 10G
+# - system partition #2, 10G
+# - state & /home partition, 10G
+# this scheme permits us to install new operating systems over the air and in the future
+# simplify upgrades. during time of implementation, we have not roadmapped this OTA functionality yet.
+# ref: https://github.com/micro-nova/AmpliPi/issues/489
+#
+# A lot of this script was inspired by (or copied from) Raspberry Pi's init_resize.sh; cheers yall.
+# ref: https://github.com/RPi-Distro/raspi-config/blob/408bde537671de6df2d9b91564e67132f98ffa71/usr/lib/raspi-config/init_resize.sh
+# ref: https://github.com/RPi-Distro/raspi-config/blob/408bde537671de6df2d9b91564e67132f98ffa71/LICENSE
+
+echo "starting first boot partitioning tasks..."
+
+# bail if any command uses an unset variable
+set -u
+
+# spit out the execution of each line; in case we do bail we know where it failed
+set -x
+
+# kernel panic messages will quickly overwhelm the screen if we don't trap the exit during
+# potential troubleshooting
+trap 'sleep 10' EXIT
+
+# set up stuff a regular init might help with
+mount -t proc proc /proc
+mount -t sysfs sys /sys
+mount -t tmpfs tmp /run
+mkdir -p /run/systemd
+mount /boot
+mount / -o remount,ro
+
+ROOT_PART_DEV=$(findmnt / -o source -n)
+ROOT_PART_NAME=$(echo "${ROOT_PART_DEV}" | cut -d "/" -f 3)
+ROOT_DEV_NAME=$(echo /sys/block/*/"${ROOT_PART_NAME}" | cut -d "/" -f 4)
+ROOT_DEV="/dev/${ROOT_DEV_NAME}"
+
+# sanity checks. Should any of these conditions be true, users must manage their own
+# partitioning or reflash.
+partprobe
+blkid ${ROOT_DEV}p3
+if [ $? -eq 0 ] ; then
+  echo "${0}: detected a third partition; exiting."
+  exit 1
+fi
+
+# bail if anything exits with a non-zero exit status
+set -e
+
+# Actually partition.
+parted ${ROOT_DEV} --align optimal --script resizepart 2 34% # system partition 1
+parted ${ROOT_DEV} --align optimal --script mkpart primary 34% 67% # system partition 2
+parted ${ROOT_DEV} --align optimal --script mkpart primary 67% 100% # /home
+
+partprobe ${ROOT_DEV}
+
+# e2fsck _will_ return nonzero on this run.
+set +e
+e2fsck -f ${ROOT_DEV}p2
+if [ $? -ge 3 ]; then
+  echo "${0}: e2fsck -f ${ROOT_DEV}p2 failed; exiting"
+  exit 2
+fi
+set -e
+# resize2fs actually needs the filesystem RW
+mount / -o remount,rw
+resize2fs ${ROOT_DEV}p2
+
+sed -i 's| init=/home/pi/amplipi-dev/first_boot_partitioning||' /boot/cmdline.txt
+
+sync
+
+# fancy reboot for when we're actually init; lines from reboot_pi() in init_resize.sh
+echo b > /proc/sysrq-trigger
+sleep 5
+exit 0

--- a/scripts/first_boot_partitioning
+++ b/scripts/first_boot_partitioning
@@ -12,7 +12,7 @@
 # ref: https://github.com/RPi-Distro/raspi-config/blob/408bde537671de6df2d9b91564e67132f98ffa71/usr/lib/raspi-config/init_resize.sh
 # ref: https://github.com/RPi-Distro/raspi-config/blob/408bde537671de6df2d9b91564e67132f98ffa71/LICENSE
 
-echo "starting first boot partitioning tasks..."
+echo "${0}: starting first boot partitioning tasks..."
 
 # bail if any command uses an unset variable
 set -u
@@ -21,8 +21,9 @@ set -u
 set -x
 
 # kernel panic messages will quickly overwhelm the screen if we don't trap the exit during
-# potential troubleshooting
-trap 'sleep 10' EXIT
+# potential troubleshooting. it feels most sane to "try again" with a reboot; our other option
+# is to halt.
+trap 'sleep 5; mount -o remount,ro / ; umount /boot ; sleep 5; echo b > /proc/sysrq-trigger; sleep 5' EXIT
 
 # set up stuff a regular init might help with
 mount -t proc proc /proc
@@ -30,7 +31,7 @@ mount -t sysfs sys /sys
 mount -t tmpfs tmp /run
 mkdir -p /run/systemd
 mount /boot
-mount / -o remount,ro
+mount -o remount,rw /
 
 ROOT_PART_DEV=$(findmnt / -o source -n)
 ROOT_PART_NAME=$(echo "${ROOT_PART_DEV}" | cut -d "/" -f 3)
@@ -42,37 +43,44 @@ ROOT_DEV="/dev/${ROOT_DEV_NAME}"
 partprobe
 blkid ${ROOT_DEV}p3
 if [ $? -eq 0 ] ; then
-  echo "${0}: detected a third partition; exiting."
+  echo "${0}: detected a third partition; removing this script from initial boot & exiting."
+  sed -i 's/ init=\/home\/pi\/amplipi-dev\/scripts\/first_boot_partitioning//' /boot/cmdline.txt
   exit 1
 fi
 
 # bail if anything exits with a non-zero exit status
 set -e
 
-# Actually partition.
-parted ${ROOT_DEV} --align optimal --script resizepart 2 34% # system partition 1
+# Set up our partitioning scheme.
 parted ${ROOT_DEV} --align optimal --script mkpart primary 34% 67% # system partition 2
 parted ${ROOT_DEV} --align optimal --script mkpart primary 67% 100% # /home
-
 partprobe ${ROOT_DEV}
+# copy system partition 1 to system partition 2, and resize both filesystems to fill
+echo "${0}: creating recovery partition..."
+mount -o remount,ro /
+sleep 5
+dd if=${ROOT_DEV}p2 of=${ROOT_DEV}p3 bs=2M oflag=dsync status=progress
+mount -o remount,rw /
+parted ${ROOT_DEV} --align optimal --script resizepart 2 34% # system partition 1
 
-# e2fsck _will_ return nonzero on this run.
-set +e
-e2fsck -f ${ROOT_DEV}p2
-if [ $? -ge 3 ]; then
-  echo "${0}: e2fsck -f ${ROOT_DEV}p2 failed; exiting"
-  exit 2
-fi
-set -e
-# resize2fs actually needs the filesystem RW
-mount / -o remount,rw
-resize2fs ${ROOT_DEV}p2
+# then repair and expand our filesystems within these partitions
+for PART in ${ROOT_DEV}p2 ${ROOT_DEV}p3; do
+    # we don't run e2fsck on the mounted root partition.
+    if [ ${PART} != ${ROOT_DEV}p2 ]; then
+        # e2fsck sometimes returns >0 when it's successful.
+        set +e
+        e2fsck -f ${PART}
+        if [ $? -ge 3 ]; then
+          echo "${0}: e2fsck -f ${PART} failed; continuing anyways."
+        fi
+        set -e
+    fi
 
-sed -i 's| init=/home/pi/amplipi-dev/first_boot_partitioning||' /boot/cmdline.txt
+    resize2fs ${PART}
+done
+
+sed -i 's/ init=\/home\/pi\/amplipi-dev\/scripts\/first_boot_partitioning//' /boot/cmdline.txt
 
 sync
 
-# fancy reboot for when we're actually init; lines from reboot_pi() in init_resize.sh
-echo b > /proc/sysrq-trigger
-sleep 5
-exit 0
+sleep 3

--- a/scripts/first_boot_partitioning
+++ b/scripts/first_boot_partitioning
@@ -44,7 +44,7 @@ partprobe
 blkid ${ROOT_DEV}p3
 if [ $? -eq 0 ] ; then
   echo "${0}: detected a third partition; removing this script from initial boot & exiting."
-  sed -i 's/ init=\/home\/pi\/amplipi-dev\/scripts\/first_boot_partitioning//' /boot/cmdline.txt
+  sed -i 's| init=/home/pi/amplipi-dev/scripts/first_boot_partitioning||' /boot/cmdline.txt
   exit 1
 fi
 
@@ -75,7 +75,7 @@ parted ${ROOT_DEV} --align optimal --script resizepart 2 34% # system partition 
 
 # then repair and expand our filesystems within these partitions
 for PART in ${ROOT_DEV}p2 ${ROOT_DEV}p3; do
-    # we don't run e2fsck on the mounted root partition.
+    # we don't run e2fsck on the mounted root partition, because it is mounted.
     if [ ${PART} != ${ROOT_DEV}p2 ]; then
         # e2fsck sometimes returns >0 when it's successful.
         set +e
@@ -89,7 +89,7 @@ for PART in ${ROOT_DEV}p2 ${ROOT_DEV}p3; do
     resize2fs ${PART}
 done
 
-sed -i 's/ init=\/home\/pi\/amplipi-dev\/scripts\/first_boot_partitioning//' /boot/cmdline.txt
+sed -i 's| init=/home/pi/amplipi-dev/scripts/first_boot_partitioning||' /boot/cmdline.txt
 
 sync
 

--- a/scripts/first_boot_partitioning
+++ b/scripts/first_boot_partitioning
@@ -51,10 +51,20 @@ fi
 # bail if anything exits with a non-zero exit status
 set -e
 
-# Set up our partitioning scheme.
-parted ${ROOT_DEV} --align optimal --script mkpart primary 34% 67% # system partition 2
-parted ${ROOT_DEV} --align optimal --script mkpart primary 67% 100% # /home
+# Set up our partitioning scheme, 4 total partitions:
+# #    % Name
+# 1  <1% /boot
+# 2 ~33% system partition 1
+# 3 ~33% system partition 2
+# 4 ~33% /home
+#
+# At this point (directly after first imaging) p1 and p2 already exist.
+# p1 we will leave unchanged, p2 is currently shrunk as small as possible.
+# Leave p2 shrunk for now so as to reduce copy time.
+parted ${ROOT_DEV} --align optimal --script mkpart primary 34% 67% # Create system partition 2
+parted ${ROOT_DEV} --align optimal --script mkpart primary 67% 100% # Create /home
 partprobe ${ROOT_DEV}
+
 # copy system partition 1 to system partition 2, and resize both filesystems to fill
 echo "${0}: creating recovery partition..."
 mount -o remount,ro /


### PR DESCRIPTION
Since we don't manage `/boot/cmdline.txt` (yet), I think this PR is feature-complete and implements #489 . This is used during initial boot, whereby the kernel is informed that _this_ script is actually `init` in `/boot/cmdline.txt`. At the end of this script, it removes this operand. This same procedure (and a decent chunk of the errata) was gently re-utilized from [raspi-config's `init_resize.sh`](https://github.com/RPi-Distro/raspi-config/blob/408bde537671de6df2d9b91564e67132f98ffa71/usr/lib/raspi-config/init_resize.sh); cheers on the wisdom & code.

This has been tested and run a handful of times with a custom image; when this is accepted, I'll bake an image with this.

One day I'd like to make an `amplipi-scripts` package or similar, because it feels real awkward to host a fake init in `/home` (especially since that will eventually be a different partition), but that's not for today.

On our current CM3's with 32G of memory, the partitioning table ends up looking like this:
```bash
pi@amplipi:~$ sudo parted /dev/mmcblk0
GNU Parted 3.2
Using /dev/mmcblk0
Welcome to GNU Parted! Type 'help' to view a list of commands.
(parted) p                                                                
Model: MMC BJTD4R (sd/mmc)
Disk /dev/mmcblk0: 31.3GB
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags: 

Number  Start   End     Size    Type     File system  Flags
 1      4194kB  273MB   268MB   primary  fat32        lba
 2      273MB   10.6GB  10.4GB  primary  ext4
 3      10.6GB  20.9GB  10.3GB  primary
 4      20.9GB  31.3GB  10.3GB  primary
```