### PR TITLE
Webapp2 lock volume

### DIFF
--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -72,6 +72,7 @@ class fields(SimpleNamespace):
   GroupVolume = Field(ge=MIN_VOL_DB, le=MAX_VOL_DB, description='Average output volume')
   GroupVolumeF = Field(ge=MIN_VOL_F, le=MAX_VOL_F, description='Average output volume as a floating-point number')
   Disabled = Field(description='Set to true if not connected to a speaker')
+  Locked = Field(description='Set to true to make volume level static')
   Zones = Field(description='Set of zone ids belonging to a group')
   Groups = Field(description='List of group ids')
   AudioInput = Field('', description="""Connected audio source
@@ -249,6 +250,7 @@ class Zone(Base):
             'vol_min': MIN_VOL_DB,
             'vol_max': MAX_VOL_DB,
             'disabled': False,
+            'lock': False,
           }
         },
         'Dining Room' : {
@@ -261,6 +263,7 @@ class Zone(Base):
             'vol_min': int(0.1 * (MAX_VOL_DB + MIN_VOL_DB)),
             'vol_max': int(0.8 * (MAX_VOL_DB + MIN_VOL_DB)),
             'disabled': False,
+            'lock': False,
           }
         },
       }
@@ -275,6 +278,7 @@ class ZoneUpdate(BaseUpdate):
   vol_min: Optional[int] = fields.VolumeMin
   vol_max: Optional[int] = fields.VolumeMax
   disabled: Optional[bool] = fields.Disabled
+  lock: Optional[bool] = fields.Lock
 
   class Config:
     schema_extra = {
@@ -1007,6 +1011,7 @@ class Status(BaseModel):
                           'type': 'internetradio',
                           'url': 'http://www.beatlesradio.com:8000/stream/1/'}],
             'zones': [ { 'disabled': False,
+                        'lock': False,
                         'id': 0,
                         'mute': True,
                         'name': 'Software Office',
@@ -1016,6 +1021,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 1,
                         'mute': True,
                         'name': 'Upstairs Living Room',
@@ -1025,6 +1031,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 2,
                         'mute': True,
                         'name': 'Upstairs Dining',
@@ -1034,6 +1041,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 3,
                         'mute': True,
                         'name': 'Upstairs Laundry',
@@ -1043,6 +1051,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 4,
                         'mute': True,
                         'name': 'Upstairs Kitchen High',
@@ -1052,6 +1061,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 5,
                         'mute': True,
                         'name': 'Upstairs Master Bath',
@@ -1061,6 +1071,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 6,
                         'mute': True,
                         'name': 'Upstairs Kitchen Low HV',
@@ -1070,6 +1081,7 @@ class Status(BaseModel):
                         'vol_max': -30,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 7,
                         'mute': True,
                         'name': 'Hardware Office HV',
@@ -1079,6 +1091,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 8,
                         'mute': True,
                         'name': 'Basement Workshop HV',
@@ -1088,6 +1101,7 @@ class Status(BaseModel):
                         'vol_max': -10,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 9,
                         'mute': True,
                         'name': 'Screened Room HV',
@@ -1097,6 +1111,7 @@ class Status(BaseModel):
                         'vol_max': -15,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 10,
                         'mute': True,
                         'name': 'Upstairs Deck Living HV',
@@ -1106,6 +1121,7 @@ class Status(BaseModel):
                         'vol_max': -15,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 11,
                         'mute': True,
                         'name': 'Upstairs Main Bedroom HV',
@@ -1115,6 +1131,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 12,
                         'mute': True,
                         'name': 'Downstairs Living Room',
@@ -1124,6 +1141,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 13,
                         'mute': True,
                         'name': 'Downstairs Dining',
@@ -1133,6 +1151,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 14,
                         'mute': True,
                         'name': 'Downstairs Bath',
@@ -1142,6 +1161,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 15,
                         'mute': True,
                         'name': 'Downstairs Laundry',
@@ -1151,6 +1171,7 @@ class Status(BaseModel):
                         'vol_max': -20,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 16,
                         'mute': True,
                         'name': 'Upstairs Main Bath',
@@ -1160,6 +1181,7 @@ class Status(BaseModel):
                         'vol_max': -30,
                         'vol_min': -70},
                       { 'disabled': False,
+                        'lock': False,
                         'id': 17,
                         'mute': True,
                         'name': 'Downstairs Bedroom',

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -98,6 +98,7 @@ class fields_w_default(SimpleNamespace):
   GroupVolume = Field(default=MIN_VOL_F, ge=MIN_VOL_F, le=MAX_VOL_F, description='Average output volume')
   GroupVolumeF = Field(default=MIN_VOL_F, ge=MIN_VOL_F, le=MAX_VOL_F, description='Average output volume as a floating-point number')
   Disabled = Field(default=False, description='Set to true if not connected to a speaker')
+  Lock = Field(default=False, description='Set to true if you want to prevent volume changes')
 
 class Base(BaseModel):
   """ Base class for AmpliPi Models
@@ -227,6 +228,7 @@ class Zone(Base):
   vol_min: int = fields_w_default.VolumeMin
   vol_max: int = fields_w_default.VolumeMax
   disabled: bool = fields_w_default.Disabled
+  lock: bool = fields_w_default.Lock
 
   def as_update(self) -> 'ZoneUpdate':
     """ Convert to ZoneUpdate """

--- a/tests/test_ctrl.py
+++ b/tests/test_ctrl.py
@@ -22,7 +22,7 @@ vol = 0
 for zone in GOOD_STATUS['zones']:
   vol += zone['vol_f']
 vol_f = vol / len( GOOD_STATUS['zones'])
-GOOD_STATUS['groups'] = [{'id': 100, 'name': 'test group', 'mute': True, 'vol_f': vol_f, 'source_id': 0, 'zones': [0, 1, 2, 3, 4, 5]}]
+GOOD_STATUS['groups'] = [{'id': 100, 'name': 'test group', 'mute': True, 'lock': False, 'vol_f': vol_f, 'source_id': 0, 'zones': [0, 1, 2, 3, 4, 5]}]
 GOOD_CONFIG = json.dumps(GOOD_STATUS) # make it a json string we can write to a config file
 # corrupt the json string by only taking the first half
 # ( simulating what would happen if the program was terminated while writing the config file)

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -95,6 +95,30 @@ export const useStatusStore = create((set, get) => ({
             })
         );
     },
+    setZonesLock: (lock, zones, source_id) => {
+        set(
+            produce((s) => {
+                for (const i of getSourceZones(source_id, zones)) {
+                    for (const j of s.status.zones) {
+                        if (j.id === i.id) {
+                            j.lock = lock;
+                        }
+                    }
+                }
+            })
+        );
+    },
+    setZoneLock: (zid, lock) => {
+        set(
+            produce((s) => {
+                for (const i of s.status.zones) {
+                    if (i.id === zid) {
+                        i.lock = lock;
+                    }
+                }
+            })
+        );
+    },
     setGroupMute: (gid, mute) => {
         set(
             produce((s) => {

--- a/web/src/components/CardVolumeSlider/CardVolumeSlider.jsx
+++ b/web/src/components/CardVolumeSlider/CardVolumeSlider.jsx
@@ -87,10 +87,31 @@ const CardVolumeSlider = ({ sourceId }) => {
         });
     };
 
+    const lock = getSourceZones(sourceId, zones)
+        .map((z) => z.lock)
+        .reduce((a, b) => a && b, true);
+
+
+    const setLock = (lock) => {
+        setZonesLock(lock, zones, sourceId);
+        fetch("/api/zones", {
+            method: "PATCH",
+            headers: {
+                "Content-type": "application/json",
+            },
+            body: JSON.stringify({
+                zones: getSourceZones(sourceId, zones).map((z) => z.id),
+                update: { lock: lock },
+            }),
+        });
+    };
+
     return (
         <div className="volume-slider">
             <VolumeSlider
                 vol={value}
+                lock={lock}
+                setLock={setLock}
                 mute={mute}
                 setMute={setMute}
                 setVol={(val, force = false) => {

--- a/web/src/components/VolumeSlider/VolumeSlider.jsx
+++ b/web/src/components/VolumeSlider/VolumeSlider.jsx
@@ -58,7 +58,7 @@ const VolumeSlider = ({ vol, mute, lock, setVol, setMute, setLock, disabled }) =
                     <VolIcon vol={vol} mute={mute} />
                 </div>
                 <Slider
-                    disabled={disabled}
+                    disabled={disabled || lock}
                     className="volume-slider"
                     min={0}
                     step={0.01}

--- a/web/src/components/VolumeSlider/VolumeSlider.jsx
+++ b/web/src/components/VolumeSlider/VolumeSlider.jsx
@@ -8,7 +8,11 @@ import VolumeOffIcon from "@mui/icons-material/VolumeOff";
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import StopProp from "@/components/StopProp/StopProp";
 
+import LockOpenOutlinedIcon from '@mui/icons-material/LockOpenOutlined';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+
 import PropTypes from "prop-types";
+import { IconButton } from "@mui/material";
 
 const VolIcon = ({ vol, mute }) => {
     if (mute) {
@@ -32,10 +36,19 @@ VolIcon.propTypes = {
 };
 
 // generic volume slider used by other volume sliders
-const VolumeSlider = ({ vol, mute, setVol, setMute, disabled }) => {
+const VolumeSlider = ({ vol, mute, lock, setVol, setMute, setLock, disabled }) => {
     return (
         <StopProp>
             <div className="volume-slider-container">
+                <div
+                    onClick={() => {
+                        setLock(!lock);
+                    }}
+                    className="volume-slider-icon-container"
+                >
+                  {!lock && <IconButton><LockOpenOutlinedIcon /></IconButton>}
+                  {lock && <IconButton><LockOutlinedIcon /></IconButton>}
+                </div>
                 <div
                     onClick={() => {
                         setMute(!mute);
@@ -65,11 +78,15 @@ const VolumeSlider = ({ vol, mute, setVol, setMute, disabled }) => {
 VolumeSlider.propTypes = {
     vol: PropTypes.number.isRequired,
     mute: PropTypes.bool.isRequired,
+    lock: PropTypes.bool,
     setVol: PropTypes.func.isRequired,
     setMute: PropTypes.func.isRequired,
+    setLock: PropTypes.func,
     disabled: PropTypes.bool,
 };
 VolumeSlider.defaultProps = {
+    lock: false,
+    setLock: () => {},
     disabled: false,
 };
 

--- a/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.jsx
+++ b/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.jsx
@@ -12,10 +12,13 @@ const ZoneVolumeSlider = ({ zoneId }) => {
     const zoneName = useStatusStore((s) => s.status.zones[zoneId].name);
     const volume = useStatusStore((s) => s.status.zones[zoneId].vol_f);
     const mute = useStatusStore((s) => s.status.zones[zoneId].mute);
+    const lock = useStatusStore((s) => s.status.zones[zoneId].lock);
     const setZoneVol = useStatusStore((s) => s.setZoneVol);
     const setZoneMute = useStatusStore((s) => s.setZoneMute);
+    const setZoneLock = useStatusStore((s) => s.setZoneLock);
 
     const setVol = (vol, force = false) => {
+      if(!lock){
         setZoneVol(zoneId, vol);
 
         if (sendingRequestCount <= 0 || force) {
@@ -31,6 +34,7 @@ const ZoneVolumeSlider = ({ zoneId }) => {
                 sendingRequestCount -= 1;
             });
         }
+      }
     };
 
     const setMute = (mute) => {
@@ -45,10 +49,24 @@ const ZoneVolumeSlider = ({ zoneId }) => {
         });
     };
 
+    const setLock = (lock) => {
+        setZoneLock(zoneId, lock);
+
+        fetch(`/api/zones/${zoneId}`, {
+            method: "PATCH",
+            headers: {
+                "Content-type": "application/json",
+            },
+            body: JSON.stringify({ lock: lock }),
+        });
+    };
+
     return (
         <div className="zone-volume-container">
             {zoneName}
             <VolumeSlider
+                lock={lock}
+                setLock={setLock}
                 mute={mute}
                 setMute={setMute}
                 vol={volume}


### PR DESCRIPTION
Adding a lock to the volume sliders on the frontend (and logic to support it to the backend) that will allow volume to be locked so that it can't be changed, generally useful when a zone is part of a group but doesn't want to be effected by the same volume changes as the group as a whole