### PR TITLE
feat: add development flag to scripts/configure.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+node_modules/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -133,6 +134,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vi
+*.swp
 
 # emacs
 *~

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Jinja2==3.1.2
 loguru==0.6.0
 mypy==1.0.0
 netifaces==0.11.0
-numpy==1.21.6
+numpy
 Pillow==9.4.0
 psutil==5.9.4
 pydantic==1.10.4

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -992,6 +992,6 @@ if __name__ == '__main__':
   result = install(os_deps=flags.os_deps, python_deps=flags.python_deps, web=flags.web,
           display=flags.display, audiodetector=flags.audiodetector,
           firmware=flags.firmware, password=flags.password,
-          restart_updater=flags.restart_updater)
+          restart_updater=flags.restart_updater, development=flags.development)
   if not result:
     sys.exit(1)

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -989,7 +989,9 @@ if __name__ == '__main__':
     print('  WARNING: expected some arguments, check --help for more information')
   if sys.version_info.major < 3 or sys.version_info.minor < 7:
     print('  WARNING: minimum python version is 3.7')
-  install(os_deps=flags.os_deps, python_deps=flags.python_deps, web=flags.web,
+  result = install(os_deps=flags.os_deps, python_deps=flags.python_deps, web=flags.web,
           display=flags.display, audiodetector=flags.audiodetector,
           firmware=flags.firmware, password=flags.password,
           restart_updater=flags.restart_updater)
+  if not result:
+    sys.exit(1)

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -882,7 +882,7 @@ def add_tests(env, progress) -> List[Task]:
 
 def install(os_deps=True, python_deps=True, web=True, restart_updater=False,
             display=True, audiodetector=True, firmware=True, password=True,
-            progress=print_task_results) -> bool:
+            progress=print_task_results, development=False) -> bool:
   """ Install and configure AmpliPi's dependencies """
   # pylint: disable=too-many-return-statements
   tasks = [Task('setup')]
@@ -893,7 +893,7 @@ def install(os_deps=True, python_deps=True, web=True, restart_updater=False,
     return False
 
   env = _check_and_setup_platform()
-  if not env['platform_supported']:
+  if not env['platform_supported'] and not development:
     tasks[0].output = f'untested platform: {platform.platform()}. Please fix this script and make a PR to github.com/micro-nova/AmpliPi'
   else:
     tasks[0].output = str(env)
@@ -980,6 +980,8 @@ if __name__ == '__main__':
     help="Flash the latest firmware")
   parser.add_argument('--password', action='store_true', default=False,
     help="Generate and set a new default password for the pi user.")
+  parser.add_argument('--development', action='store_true', default=False,
+    help="Enable development mode.")
   flags = parser.parse_args()
   print('Configuring AmpliPi installation')
   has_args = flags.python_deps or flags.os_deps or flags.web or flags.restart_updater or flags.display or flags.firmware


### PR DESCRIPTION
This PR adds a simple `--development` flag to `scripts/configure.py`. At present, it simply disregards the platform checking; I suspect it could be helpful to use elsewhere too though.

Also, `.gitignore`: we now have errant `node_modules/` floating around cuz of `webapp_2` development, and also my `.swp` files from `vi`.