### PR TITLE
Prevent node_modules from being deployed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ gmrender-resurrect
 # Amplipi Web
 web/generated/*
 web/uploads/*
+web/node_modules/*
 
 # Firmware builds
 fw/preamp/Debug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amplipi"
-version = "0.2.1+731258c-Webapp2-RUM-dirty"
+version = "0.3.0+3d268f1-upstream_lms-dirty"
 description = "A Pi-based whole house audio controller"
 authors = [
   "Lincoln Lorenz <lincoln@micro-nova.com>",
@@ -39,10 +39,9 @@ include = [
   "hw/**",
   "scripts/*",
   "streams/**/*",
-  "web/**/*",
-  "web2/**/*",
   "bin/**",
   "docs/**",
+  "web/dist"
 ]
 exclude = [
   "scripts/deploy", "scripts/bootstrap_pi" # only support development

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -144,6 +144,13 @@ else
 fi
 poetry version ${git_info}
 
+# build webapp
+echo "Building web app"
+pushd ../web                                                 # Change to web directory
+npm install                                                       # Install nodejs dependencies
+npm run build                                                     # Build the web app
+popd
+
 # build release file (put in dist/)
 poetry build
 
@@ -152,15 +159,6 @@ poetry version $old_version
 
 # exit virtual environment
 deactivate
-
-# build webapp
-echo "Building web app"
-pushd ../web                                                 # Change to web directory
-npm install                                                       # Install nodejs dependencies
-npm run build                                                     # Build the web app
-cp node_modules /tmp/amplipi_nm -r                                # Copy node_modules to /tmp so it can be saved
-rm node_modules -r                                                # Remove node_modules so we don't copy it over
-popd
 
 # setup ssh access if necessary
 if ! ssh -o PasswordAuthentication=no $user_host 'echo "AmpliPi has your SSH Key"'; then
@@ -190,10 +188,6 @@ opts=""
 $fw && opts="$opts --firmware"
 $pw && opts="$opts --password"
 ssh $user_host -t "python3 amplipi-dev/scripts/configure.py --os-deps --python-deps --web --restart-updater --display --audiodetector$opts" || echo ""
-
-# restore node_modules
-cp /tmp/amplipi_nm ../web/node_modules -r
-rm /tmp/amplipi_nm -r
 
 echo -e "Waiting for AmpliPi to restart\n"
 restart_finished=false


### PR DESCRIPTION
The location of the `node_modules` stuff in #533 was incorrect; `poetry build` creates the tarball that is deployed, and this moves that command to after `mv node_modules [...]`.