### PR TITLE
Switch to trunk based development & explicit semantic versioning

### DIFF
--- a/NEW_RELEASE.md
+++ b/NEW_RELEASE.md
@@ -2,19 +2,6 @@
 
 So you think you are ready to make a release, eh? Follow the steps below :)
 
-## Making a prelease
-- [ ] Merge main into develop
-- [ ] Make a branch off develop called VERSION-prelease
-- [ ] Update the changelog with notes and the latest version (and commit it!)
-- [ ] Update the API by running the `scripts/create_spec` script and commit the resulting changes to `docs/amplipi_api.yaml` with `git commit --patch -m "Update API specification used by GitHub Pages"`
-- [ ] Build the webapp with `npm run build` and force add the changes with `git add -f web/dist`
-- [ ] Use poetry to bump the version with `poetry version ${VERSION}-alpha.0 && git add pyproject.toml && git commit -m "Bump pre-release version"`
-- [ ] Tag the changes so we can make a pre-release on GitHub `git tag -as ${VERSION}-alpha.0 -m '' && git push origin ${VERSION}-alpha.0`
-- [ ] Make a pre-release using the GitHub interface
-- [ ] Use the AmpliPi updater to update to the pre-release
-- [ ] Test it (see below), if it needs changes follow the steps above again but stay on the pre-release branch and increment the number after alpha eg `alpha8`
-- When it works skip below to [Finalizing the release](#finalizing-the-release)
-
 ## Testing
 - [ ] Web App (use chrome, firefox, and safari)
   - [ ] Test group and zone volume control
@@ -34,11 +21,19 @@ So you think you are ready to make a release, eh? Follow the steps below :)
   - [ ] Update end-of-line tester with new release
   - [ ] Verify all tests function
 
-## Finalizing the release
-Alright so the release is tested and it actually works! Nice!
-- [ ] merge the prerelease branch into develop and merge that into the main branch
-- [ ] use poetry to bump the version `poetry version ${VERSION} && git add pyproject.toml && git commit -m "Bump release"`
-- [ ] use git to delete any prelease tags `git push origin -d $(git tag -l "${VERSION}-alpha*") && git tag -d $(git tag -l "${VERSION}-alpha*")`
-- [ ] Tag the changes so we can make a release on GitHub `git tag -as ${VERSION} -m '' && git push --follow-tags`
-- [ ] Make a release using the GitHub interface, add notes from the CHANGELOG.md
-- [ ] Make a new Raspberry Pi image to program onto units before shipping.
+## Versioning
+This project follows [Semantic Versioning](https://semver.org/). Here are some examples of versions we've used before:
+* `0.2.1`: this is a public general-availability bugfix release of the `0.2` feature release.
+* `0.3.0-alpha.0` is the first alpha release of the `0.3` feature release.
+
+## Making a release
+- [ ] Ensure the PR(s) with your features & fixes are merged into `main`.
+- [ ] Check out and pull `main`
+- [ ] Update the changelog with notes and the latest version (and commit it!)
+- [ ] Build the webapp in `web` with `npm run build` and force add the changes with `git add -f web/dist; git commit -m "Build web app for release"`
+- [ ] Update the API by running the `scripts/create_spec` script and commit the resulting changes to `docs/amplipi_api.yaml` with `git commit --patch -m "Update API specification used by GitHub Pages"`
+- [ ] Use poetry to bump the version with `poetry version ${VERSION} && git add pyproject.toml && git commit -m "Bump version"`
+- [ ] Tag the changes so we can make a release on GitHub: `git tag -as ${VERSION} -m '' && git push origin ${VERSION}`
+- [ ] Make a release using the GitHub interface
+- [ ] Use the AmpliPi updater to update to the release
+- [ ] Test it again! If it needs changes, pull request your bugfixes against `main` and stamp a new release 😎

--- a/NEW_RELEASE.md
+++ b/NEW_RELEASE.md
@@ -28,12 +28,12 @@ This project follows [Semantic Versioning](https://semver.org/). Here are some e
 
 ## Making a release
 - [ ] Ensure the PR(s) with your features & fixes are merged into `main`.
-- [ ] Check out and pull `main`
-- [ ] Update the changelog with notes and the latest version (and commit it!)
+- [ ] Create & merge a branch/PR off `main` to bump the version in the CHANGELOG and also using `poetry version ${VERSION}`
+- [ ] Create another branch off `main` named the version number (ie, `0.3.0`.)
 - [ ] Build the webapp in `web` with `npm run build` and force add the changes with `git add -f web/dist; git commit -m "Build web app for release"`
 - [ ] Update the API by running the `scripts/create_spec` script and commit the resulting changes to `docs/amplipi_api.yaml` with `git commit --patch -m "Update API specification used by GitHub Pages"`
-- [ ] Use poetry to bump the version with `poetry version ${VERSION} && git add pyproject.toml && git commit -m "Bump version"`
 - [ ] Tag the changes so we can make a release on GitHub: `git tag -as ${VERSION} -m '' && git push origin ${VERSION}`
 - [ ] Make a release using the GitHub interface
+- [ ] Remove the branch (but not the tag) from Github, or else the ref is ambiguous to Github and the updater fails to download the right tarball.
 - [ ] Use the AmpliPi updater to update to the release
 - [ ] Test it again! If it needs changes, pull request your bugfixes against `main` and stamp a new release 😎


### PR DESCRIPTION
This PR updates our release documentation. This came up because of some oddities during the stamping of the 0.3.0 release candidate 0. 

I'm trying to more closely follow a [more conventional trunk-based development](https://trunkbaseddevelopment.com/), where there exists only one trunk and version branches never get merged back into `main`. As the doc was before this PR, we'd at least be merging compiled javascript back into `main` regularly, which is no bueno. I think it's also a bit simpler and cleaner.