### PR TITLE
Do not After=network.target the -display & audiodetector services

### DIFF
--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -502,7 +502,6 @@ def _display_service(directory: str):
   return f"""\
 [Unit]
 Description=Amplipi Front Panel Display
-After=network.target
 
 [Service]
 Type=simple
@@ -518,7 +517,6 @@ def _audiodetector_service(directory: str):
   return f"""\
 [Unit]
 Description=Amplipi RCA Input Audio Detector
-After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
During some network oddities where the network initialization does not start or fail quickly but hangs for a long time, the display and audiodetector services also hang. I've removed that "weak dependency". This potentially allows us to give better feedback during bootup.

This still needs to be tested, in particular because of the display service potentially having a true dependency on networking at the moment; thus, I've filed this as a draft for now.