### PR TITLE
fix regression introduced in Spotify bugfix

### DIFF
--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -570,10 +570,10 @@ class Spotify(PersistentStream):
   def _deactivate(self):
     try:
       self.proc.terminate()
-      outs, errs = self.proc.communicate(timeout=3)
+      self.proc.communicate(timeout=3)
     except Exception as e:
       print(f"failed to terminate spotify stream: {e}")
-      kouts, kerrs = self.proc.kill()
+      self.proc.kill()
     try:
       del self.mpris
     except Exception:


### PR DESCRIPTION
This PR fixes a bug introduced during #565 ; we don't use the outputs of `communicate`, and `kill` doesn't even output. The tests failed on this; it's not clear why Github let me merge anyhow, when our branch protections require passing tests for everybody, including administrators :woozy_face: 