### PR TITLE
Manually correct version for impending release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amplipi"
-version = "0.3.0+3d268f1-upstream_lms-dirty"
+version = "0.3.0"
 description = "A Pi-based whole house audio controller"
 authors = [
   "Lincoln Lorenz <lincoln@micro-nova.com>",


### PR DESCRIPTION
This PR manually corrects the version listed in pyproject.toml for the impending GA release of 0.3.0.