### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 # AmpliPi Software Releases
 
-## Upcoming release
+## 0.3.1
+* System
+  * Fix bug between various hardware versions
+* Developing
+  * Fix software and hardware tests
+
+## 0.3.0
 * Streams
   * Add Bluetooth stream
+  * Updates to spotifyd
 * API
   * Add support for units without zones
 * Hardware
   * Add support for EEPROMS on boards to identify board type and revision
   * Add support for E-Ink display
+* Web App
+  * Completely rewritten web app using React
+* System
+  * Add Logitech Media Server as an optional backend
 
 ## 0.2.1
 * System

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amplipi"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Pi-based whole house audio controller"
 authors = [
   "Lincoln Lorenz <lincoln@micro-nova.com>",


### PR DESCRIPTION
This PR bumps the version to 0.3.1. This is a test flight of the lest procedure documented in #559 ; it differs from that in that we're PR'ing to `develop` and not `main` (cuz we haven't merged `develop` into main or killed `develop` yet.)