### PR TITLE
Update requests in requirements.txt to avoid vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pytest-dependency==0.5.1
 python-multipart==0.0.5
 python-vlc==3.0.18121
 PyYAML==6.0
-requests==2.28.2
+requests==2.31.0
 RPi.GPIO==0.7.1
 smbus2==0.4.2
 spidev


### PR DESCRIPTION
# What does this change intend to accomplish?
I recently discovered https://github.com/micro-nova/AmpliPi/security/dependabot, and while I don't know anything about `npm` I took a look at the `pip` packages. Most of them aren't upgradeable until we get a new Python version, but `requests` can be upgraded to avoid https://github.com/micro-nova/AmpliPi/security/dependabot/4. 
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
