### PR TITLE
Update scripts/tests and Github workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,11 +1,9 @@
+# Ensure the preamp firmware at least builds.
+# It would be nice to eventually add dedicated test AmpliPi hardware
+# that Github can target and run real tests on.
+
 name: CMake
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main, develop ]
-
+on: pull_request
 jobs:
   preamp-build:
     name: Build Preamp firmware

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,13 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python application
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main, develop ]
-
+on: pull_request
 jobs:
   python-tests:
     name: Run python linting and tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,12 +45,10 @@ jobs:
         pytest tests/test_rest.py -vvv -k 'not _live' --cov=./ --cov-report=xml
         pytest tests/test_auth.py -vvv
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
-        directory: ./coverage/reports/
         flags: unittests
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: false
-        path_to_write_report: ./coverage/codecov_report.txt

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,8 +25,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libgirepository1.0-dev libcairo2-dev libdbus-1-dev # required for dbus
         python -m pip install --upgrade pip
-        pip install pylint mypy pytest pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install pylint mypy pytest pytest-cov # Add any testing dependencies not in requirements.txt
     - name: Lint with pylint
       run: |
         pylint --exit-zero amplipi --generated-members "signal.Signals,GPIO.*"

--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -568,19 +568,21 @@ class Spotify(PersistentStream):
       print(f'error starting spotify: {exc}')
 
   def _deactivate(self):
-    try:
-      self.proc.terminate()
-      self.proc.communicate(timeout=3)
-    except Exception as e:
-      print(f"failed to terminate spotify stream: {e}")
-      self.proc.kill()
-    try:
-      del self.mpris
-    except Exception:
-      pass
+    if self.proc:
+      try:
+        self.proc.terminate()
+        self.proc.communicate(timeout=3)
+      except Exception as e:
+        print(f"failed to terminate spotify stream: {e}")
+        self.proc.kill()
+      self.proc = None
+    if self.mpris:
+      try:
+        del self.mpris
+      except Exception:
+        pass
+      self.mpris = None
     self.connect_port = None
-    self.mpris = None
-    self.proc = None
 
   def info(self) -> models.SourceInfo:
     source = models.SourceInfo(

--- a/scripts/test
+++ b/scripts/test
@@ -1,17 +1,33 @@
 #!/bin/bash
 
-# get directory that the script exists in
+# cd to the repo root
 cd "$( dirname "$0" )/.."
 source venv/bin/activate
 
-# Run pylint to check for code issues
-pylint --exit-zero amplipi --generated-members "signal.Signals,GPIO.*,RPi.GPIO.*"
-pylint -E amplipi --generated-members "signal.Signals,GPIO.*,RPi.GPIO.*"
+# Run pylint twice here to identify any code issues:
+# - First to see all of the messages without failing before we get through all of them.
+# - Second to show first failure if any.
+pylint --exit-zero amplipi --generated-members "signal.Signals,GPIO.*"
+pylint -E amplipi --generated-members "signal.Signals,GPIO.*"
 
 # Lint with mypy, static type checker
 mypy amplipi --ignore-missing-imports
 
-# Live tests require some amplipi streams to be setup
-pytest -vvv tests/test_ctrl.py # test control separately to avoid weird shared state issues
-pytest -vvv -k 'not _live' --ignore 'tests/test_ctrl.py'
+mkdir -p web/dist
+touch web/dist/index.html
+
+# Controller tests don't work well in parallel due to shared state.
+# Run all the tests here individually to serialize them.
+pytest tests/test_ctrl.py -vvv -k no_config
+pytest tests/test_ctrl.py -vvv -k good_config
+pytest tests/test_ctrl.py -vvv -k corrupted_config
+pytest tests/test_ctrl.py -vvv -k doubly_corrupted_config
+pytest tests/test_ctrl.py -vvv -k missing_config
+pytest tests/test_ctrl.py -vvv -k doubly_missing_config
+
+pytest tests/test_rest.py -vvv -k 'not _live'
+pytest tests/test_auth.py -vvv
+
+# Live tests require some amplipi streams to be setup, which means real audio
+# sinks are required. These tests will not run in Github Actions.
 pytest -vvv -k '_live'


### PR DESCRIPTION
# What does this change intend to accomplish?

Update testing. `scripts/test` now matches Github Actions more closely, and the no longer existing `develop` branch is no longer referenced in workflows files.

Also updates codcov-actions to the latest version since v1 is deprecated, and fixes a warning in the `test_patch_stream_rename` test due to trying to delete a None object.
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`