### PR TITLE
do not show disabled streams in selection modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AmpliPi Software Releases
 
+## Upcoming release
+* Web App
+  * Fixed bug that allows disabled streams to be shown & selected
+
 ## 0.3.1
 * System
   * Fix bug between various hardware versions

--- a/web/src/components/StreamsModal/StreamsModal.jsx
+++ b/web/src/components/StreamsModal/StreamsModal.jsx
@@ -80,21 +80,23 @@ const StreamsModal = ({
     let streamsList = [];
 
     for (const stream of streams) {
-        const icon = getIcon(stream.type);
-        streamsList.push(
-            <ListItem
-                name={stream.name}
-                key={stream.id}
-                onClick={() => {
-                    setStream(stream);
-                    onApply();
-                    onClose();
-                }}
-                nameFontSize={LIST_ITEM_FONT_SIZE}
-            >
-                <img src={icon} className="streams-modal-icon" alt="stream icon" />
-            </ListItem>
-        );
+        if (!stream.disabled) {
+            const icon = getIcon(stream.type);
+            streamsList.push(
+                <ListItem
+                    name={stream.name}
+                    key={stream.id}
+                    onClick={() => {
+                        setStream(stream);
+                        onApply();
+                        onClose();
+                    }}
+                    nameFontSize={LIST_ITEM_FONT_SIZE}
+                >
+                    <img src={icon} className="streams-modal-icon" alt="stream icon" />
+                </ListItem>
+            );
+        }
     }
 
     return (


### PR DESCRIPTION
### What does this change intend to accomplish?
Disabled streams no longer show up in the selection dialog. This PR fixes #574 
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`