### PR TITLE
deploy /boot/config.txt with configure.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Close the preset modal when the preset has been executed
 * Make zeroconf advertisement more robust to ip address changes
 * Remove deprecated old zeroconf advertisement
+* System
+  * Manage the /boot/config.txt Raspberry Pi firmware configuration file for bugfixes
 
 ## 0.3.1
 * System

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ include = [
   "config/*.conf",
   "config/bluetooth/*",
   "config/*.rules",
+  "config/boot_config.txt",
   "debs/**/*",
   "fw/*.sh", # no need to add full source tree
   "fw/bin/*",

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -370,6 +370,10 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
     _from = f"{env['base_dir']}/config/asound.conf"
     _to = "/etc/asound.conf"
     tasks += print_progress([Task(f"copy {_from} to {_to}", f"sudo cp {_from} {_to}".split()).run()])
+    # copy boot_config.txt RPi firmware configuration file
+    _boot_config_from = f"{env['base_dir']}/config/boot_config.txt"
+    _boot_config_to = "/boot/config.txt"
+    tasks += print_progress([Task(f"copy {_boot_config_from} to {_boot_config_to}", f"sudo cp {_boot_config_from} {_boot_config_to}".split()).run()])
     # fix usb soundcard name
     usb_audio_rule_path = '/etc/udev/rules.d/85-amplipi-usb-audio.rules'
     if not os.path.exists(usb_audio_rule_path):


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR deploys /boot/config.txt on every firmware upgrade, with `configure.py`. Some older boxes had a `/boot/config.txt` that [creates problems on newer firmwares](https://amplipi.discourse.group/t/issues-after-upgrading-to-0-3-0/268/6?u=jimi). This will resolve that, at the cost of potentially overwriting an advanced user's custom `config.txt`. If we'd like to be more sophisticated about which versions we replace, I have some ideas - one is creating a list of checksums of prior config.txt revisions that can be replaced, and only replacing those.

Additionally, the version of `config/boot_config.txt` is _not_ what is currently baked into images; the diff is small:
```bash
$ diff config.txt config/boot_config.txt 
74a75,77
> 
> # Lower GPU memory from the default of 76 to 32 MB. 16 is the min but disables some features.
> gpu_mem=32
```
is there context for this change? It might be nice to get an extra 40mb of ram :)

I'm not quite sure if this should be documented elsewhere, besides the changelog.

This resolves #569 .
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
