### PR TITLE
Close presets modal after execution of preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming release
 * Web App
   * Fixed bug that allows disabled streams to be shown & selected
+  * Close the preset modal when the preset has been executed
 * Make zeroconf advertisement more robust to ip address changes
 * Remove deprecated old zeroconf advertisement
 

--- a/web/src/components/PresetsModal/PresetsModal.jsx
+++ b/web/src/components/PresetsModal/PresetsModal.jsx
@@ -89,17 +89,16 @@ const PresetsModal = ({ onClose }) => {
         fetch(`/api/presets/${id}/load`, {
             method: "POST",
             accept: "application/json",
-        })
-            .then(() =>
-                setPresetStates(
-                    presetStates.map((state, i) => (i === index ? "done" : state))
-                )
+        }).then(() =>
+            setPresetStates(
+                presetStates.map((state, i) => (i === index ? "done" : state))
             )
-            .catch(() =>
-                setPresetStates(
-                    presetStates.map((state, i) => (i === index ? false : state))
-                )
-            );
+        ).catch(() =>
+            setPresetStates(
+                presetStates.map((state, i) => (i === index ? false : state))
+            )
+        );
+        onClose();
     };
 
     const presetItems = presets.map((preset, index) => (


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR closes the preset modal after execution of the preset. This closes #590 
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`