### PR TITLE
make image_pi bail if flashing failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * System
   * Manage the /boot/config.txt Raspberry Pi firmware configuration file for bugfixes
 * Added aux input stream, a special stream that is always available and is used to select the 3.5mm input.
+* Developing
+  * Make `image_pi` script bail when the imaging is unsuccessful
 
 ## 0.3.1
 * System

--- a/scripts/image_pi
+++ b/scripts/image_pi
@@ -28,6 +28,17 @@ RED='\033[0;31m'
 GRN='\033[0;32m'
 NC='\033[0m'
 
+# Show user that an error occured before exiting
+handle_error () {
+  echo -e "\n${RED}An error occured! Imaging failed.${NC}\n"
+  read -p "Press any key to continue..." -rsn1
+  echo ""
+}
+
+# Bail if something goes wrong.
+trap handle_error ERR
+set -e
+
 img_file=''         # ...or use this image file explicitly
 instructions=true   # Skip manual instruction step
 while [[ "$#" -gt 0 ]]; do
@@ -86,8 +97,6 @@ est_time=$(echo "$img_size_mb/$write_speed_mb/60+0.5" | bc -l | cut -d'.' -f1)
 echo "Copying the image to the AmpliPi. This takes about $est_time minutes."
 echo "Go get a coffee or something :)"
 echo "Started at: $(date)"
-trap "read -p 'error! press any key to continue...'" ERR
-set -e # bail if something goes wrong.
 sudo dd if=$img_file of=$diskpath bs=4MiB status=progress
 echo "Finished at: $(date)"
 

--- a/scripts/image_pi
+++ b/scripts/image_pi
@@ -35,10 +35,6 @@ handle_error () {
   echo ""
 }
 
-# Bail if something goes wrong.
-trap handle_error ERR
-set -e
-
 img_file=''         # ...or use this image file explicitly
 instructions=true   # Skip manual instruction step
 while [[ "$#" -gt 0 ]]; do
@@ -97,7 +93,7 @@ est_time=$(echo "$img_size_mb/$write_speed_mb/60+0.5" | bc -l | cut -d'.' -f1)
 echo "Copying the image to the AmpliPi. This takes about $est_time minutes."
 echo "Go get a coffee or something :)"
 echo "Started at: $(date)"
-sudo dd if=$img_file of=$diskpath oflag=sync bs=1M status=progress
+sudo dd if=$img_file of=$diskpath oflag=sync bs=1M status=progress || handle_error
 echo "Finished at: $(date)"
 
 echo -e "

--- a/scripts/image_pi
+++ b/scripts/image_pi
@@ -86,6 +86,8 @@ est_time=$(echo "$img_size_mb/$write_speed_mb/60+0.5" | bc -l | cut -d'.' -f1)
 echo "Copying the image to the AmpliPi. This takes about $est_time minutes."
 echo "Go get a coffee or something :)"
 echo "Started at: $(date)"
+trap "read -p 'error! press any key to continue...'" ERR
+set -e # bail if something goes wrong.
 sudo dd if=$img_file of=$diskpath bs=4MiB status=progress
 echo "Finished at: $(date)"
 

--- a/scripts/image_pi
+++ b/scripts/image_pi
@@ -97,7 +97,7 @@ est_time=$(echo "$img_size_mb/$write_speed_mb/60+0.5" | bc -l | cut -d'.' -f1)
 echo "Copying the image to the AmpliPi. This takes about $est_time minutes."
 echo "Go get a coffee or something :)"
 echo "Started at: $(date)"
-sudo dd if=$img_file of=$diskpath bs=4MiB status=progress
+sudo dd if=$img_file of=$diskpath oflag=sync bs=1M status=progress
 echo "Finished at: $(date)"
 
 echo -e "


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR makes `scripts/image_pi` bail if `dd` exits with non-zero status. @mrahman313 encountered this, where a transient network error caused multiple appliances to not flash correctly, but the script still reported at the end of the run "Flashing finished" as if it were successful. This interrupts that.

I'm explicitly opting not to add a ton of debug material here besides what dd outputs; this is a quick bugfix for production to continue.
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
