### PR TITLE
remove Elastic APM RUM client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Web App
   * Fixed bug that allows disabled streams to be shown & selected
   * Close the preset modal when the preset has been executed
+  * Remove Elastic APM RUM client
 * Make zeroconf advertisement more robust to ip address changes
 * Remove deprecated old zeroconf advertisement
 * System

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,6 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
-        "@elastic/apm-rum": "^5.14.0",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
@@ -393,30 +392,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@elastic/apm-rum": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@elastic/apm-rum/-/apm-rum-5.14.0.tgz",
-      "integrity": "sha512-JyJrKAtumXpQL9X3MTkR4YTw7CzYq5O7jqpB7nVZtqgmfkKgUBAQsmQ4kkpIYhDFDKGDI+45EBj+O0ZQ9QND9w==",
-      "dependencies": {
-        "@elastic/apm-rum-core": "^5.19.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@elastic/apm-rum-core": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@elastic/apm-rum-core/-/apm-rum-core-5.19.0.tgz",
-      "integrity": "sha512-vjddutdSY2L15I0hFd45PaStleemFfxmvXj1KjiFCbRGQRW2JhMoaNJ6YpFXP+L5rs96olwXGzYLHaztWs1ciQ==",
-      "dependencies": {
-        "error-stack-parser": "^1.3.5",
-        "opentracing": "^0.14.3",
-        "promise-polyfill": "^8.1.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -1976,14 +1951,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/error-stack-parser": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
-      "integrity": "sha512-xhuSYd8wLgOXwNgjcPeXMPL/IiiA1Huck+OPvClpJViVNNlJVtM41o+1emp7bPvlCJwCatFX2DWc05/DgfbWzA==",
-      "dependencies": {
-        "stackframe": "^0.3.1"
-      }
-    },
     "node_modules/es-abstract": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
@@ -3435,14 +3402,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/opentracing": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
-      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -3627,11 +3586,6 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
-    },
-    "node_modules/promise-polyfill": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
-      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4007,11 +3961,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/stackframe": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
-      "integrity": "sha512-XmoiF4T5nuWEp2x2w92WdGjdHGY/cZa6LIbRsDRQR/Xlk4uW0PAUlH1zJYVffocwKpCdwyuypIp25xsSXEtZHw=="
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.8",

--- a/web/package.json
+++ b/web/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "engines" : { 
-    "npm" : ">=9.0.0",
-    "node" : ">=18.0.0"
+  "engines": {
+    "npm": ">=9.0.0",
+    "node": ">=18.0.0"
   },
   "scripts": {
     "dev": "vite",
@@ -14,7 +14,6 @@
     "pretty": "prettier --no-semi --write \"./**/*.{js,jsx,ts,tsx,json,css,scss}\""
   },
   "dependencies": {
-    "@elastic/apm-rum": "^5.14.0",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { create } from "zustand";
-import { init as initApm } from "@elastic/apm-rum";
 import "@/App.scss";
 import Home from "@/pages/Home/Home";
 import Player from "@/pages/Player/Player";
@@ -13,25 +12,6 @@ import { getSourceZones } from "@/pages/Home/Home";
 import DisconnectedIcon from "./components/DisconnectedIcon/DisconnectedIcon";
 
 import PropTypes from "prop-types";
-
-// const UPDATE_INTERVAL = 1000; Commented out while unused
-
-try {
-    const r = await fetch("/debug");
-    const debugDocText = await r.text();
-    const debugDoc = JSON.parse(debugDocText);
-    const debug = (debugDoc && debugDoc["debug"]) ? true : false;
-
-    var apm = initApm({ // eslint-disable-line no-unused-vars
-        active: debug,
-        serviceName: "Amplipi",
-        serverUrl: debugDoc["apmHost"] ? debugDoc["apmHost"] : "",
-        serviceVersion: debugDoc["version"] ? debugDoc["version"] : "",
-        environment: debugDoc["environment"] ? debugDoc["environment"] : ""
-    });
-} catch (error) {
-    console.error("Could not check or set debug status: ", error)
-}
 
 // holds onto the selectedSource state so that it persists between refreshes
 export const usePersistentStore = create(

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -8,9 +8,6 @@ const amplipiurl = process.env.AMPLIPI_URL || "http://127.0.0.1";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  build: {
-    target: 'es2022'
-  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -220,22 +220,6 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
-"@elastic/apm-rum-core@^5.19.0":
-  version "5.19.0"
-  resolved "https://registry.npmjs.org/@elastic/apm-rum-core/-/apm-rum-core-5.19.0.tgz"
-  integrity sha512-vjddutdSY2L15I0hFd45PaStleemFfxmvXj1KjiFCbRGQRW2JhMoaNJ6YpFXP+L5rs96olwXGzYLHaztWs1ciQ==
-  dependencies:
-    error-stack-parser "^1.3.5"
-    opentracing "^0.14.3"
-    promise-polyfill "^8.1.3"
-
-"@elastic/apm-rum@^5.14.0":
-  version "5.14.0"
-  resolved "https://registry.npmjs.org/@elastic/apm-rum/-/apm-rum-5.14.0.tgz"
-  integrity sha512-JyJrKAtumXpQL9X3MTkR4YTw7CzYq5O7jqpB7nVZtqgmfkKgUBAQsmQ4kkpIYhDFDKGDI+45EBj+O0ZQ9QND9w==
-  dependencies:
-    "@elastic/apm-rum-core" "^5.19.0"
-
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz"
@@ -967,13 +951,6 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-error-stack-parser@^1.3.5:
-  version "1.3.6"
-  resolved "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz"
-  integrity sha512-xhuSYd8wLgOXwNgjcPeXMPL/IiiA1Huck+OPvClpJViVNNlJVtM41o+1emp7bPvlCJwCatFX2DWc05/DgfbWzA==
-  dependencies:
-    stackframe "^0.3.1"
 
 es-abstract@^1.19.0, es-abstract@^1.20.4:
   version "1.22.1"
@@ -1814,11 +1791,6 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-opentracing@^0.14.3:
-  version "0.14.7"
-  resolved "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz"
-  integrity sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==
-
 optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz"
@@ -1915,11 +1887,6 @@ prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-promise-polyfill@^8.1.3:
-  version "8.3.0"
-  resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz"
-  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
@@ -2145,11 +2112,6 @@ source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
-
-stackframe@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz"
-  integrity sha512-XmoiF4T5nuWEp2x2w92WdGjdHGY/cZa6LIbRsDRQR/Xlk4uW0PAUlH1zJYVffocwKpCdwyuypIp25xsSXEtZHw==
 
 string.prototype.matchall@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR removes the Elastic APM RUM client. It has thus far not added any value to this particular project. #619 is a much better way for us to get debug insight; our issues with the frontend have very little to do with users experiencing latency or similar, but actual bugs. I've opted to leave the `/debug` endpoint in for now, because I can easily see that coming in handy in the future.

Builds succeed, but I will not merge this until I can actually test on a real AmpliPi + the old Mac we have in the office.
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
