### PR TITLE
Hide fm radio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * System
   * Add ability to display a special message for shipping on the eink display
   * Make eink display clear when the display process is stopped
+* Streams
+  * Hide FM Radio if hardware is not available
 
 ## 0.3.3
 * Web App

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -852,6 +852,7 @@ class Info(BaseModel):
   lms_mode: bool = Field(default=False, description='Are we running in LMS mode?')
   fw: List[FirmwareInfo] = Field(
     default=[], description='firmware information for each connected controller or expansion unit')
+  stream_types_available: List[str] = Field(default=[], description='The stream types available on this particular appliance')
 
   class Config:
     schema_extra = {
@@ -859,12 +860,12 @@ class Info(BaseModel):
         "System info": {
           'value': {
             'config_file': 'house.json',
-            'version': '0.1.8',
+            'version': '0.3.4',
             'mock_ctrl': False,
             'mock_streams': False,
             'is_streamer': False,
             'online': True,
-            'latest_release': '0.1.8',
+            'latest_release': '0.3.4',
             'access_key': '',
             'lms_mode': False,
             'fw': [
@@ -873,7 +874,8 @@ class Info(BaseModel):
                 "git_hash": "de0f8eb",
                 "git_dirty": False,
               }
-            ]
+            ],
+            'stream_types_available': ['bluetooth', 'fmradio']
           }
         }
       }
@@ -955,6 +957,7 @@ class Status(BaseModel):
                      'is_streamer': False,
                      'lms_mode': False,
                      'online': True,
+                     'stream_types_available': ['fmradio', 'internetradio'],
                      'version': '0.1.9'},
             'presets': [{'id': 10000,
                          'last_used': 1658242203,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ include = [
   "bin/**",
   "docs/**",
   "web/dist",
-  "web/static"
+  "web/static",
+  "web/templates"
 ]
 exclude = [
   "scripts/deploy", "scripts/bootstrap_pi" # only support development

--- a/scripts/run_debug_frontend
+++ b/scripts/run_debug_frontend
@@ -1,0 +1,4 @@
+export AMPLIPI_URL=http://127.0.0.1:5000
+pushd web
+npx vite
+popd

--- a/scripts/run_debug_webserver
+++ b/scripts/run_debug_webserver
@@ -54,5 +54,5 @@ export MOCK_CTRL=$mock_ctrl
 export MOCK_STREAMS=$mock_streams
 export WEB_PORT='5000'
 # run the uvicorn application server
-./venv/bin/python -m uvicorn --host 0.0.0.0 --port 5000 amplipi.asgi:application
+./venv/bin/python -m uvicorn --host 0.0.0.0 --port 5000 --reload --reload-dir amplipi amplipi.asgi:application
 deactivate

--- a/web/src/pages/Settings/Streams/TypeSelectModal/TypeSelectModal.jsx
+++ b/web/src/pages/Settings/Streams/TypeSelectModal/TypeSelectModal.jsx
@@ -6,27 +6,33 @@ import Modal from "@/components/Modal/Modal";
 import Card from "@/components/Card/Card";
 import { getIcon } from "@/utils/getIcon";
 import ListItem from "@/components/List/ListItem/ListItem";
+import { useStatusStore } from "@/App";
 
 const TypeSelectModal = ({ onClose, onSelect }) => {
+    const stream_types_available = useStatusStore((s) => s.status.info.stream_types_available);
+
     return (
         <>
             <Modal className="streams-modal" onClose={onClose}>
                 <Card className="type-select-card">
                     <div className="type-select-title">Select A Stream Type</div>
                     <div>
-                        {StreamTemplates.filter((t) => !t.noCreate).map((t) => {
-                            return (
-                                <ListItem
-                                    key={t.type}
-                                    name={t.name}
-                                    onClick={() => {
-                                        onSelect(t.type);
-                                        onClose();
-                                    }}
-                                >
-                                    <img className="type-icon" src={getIcon(t.type)} />
-                                </ListItem>
-                            );
+                        {StreamTemplates
+                            .filter((t) => !t.noCreate)
+                            .filter((t) => stream_types_available.includes(t.type))
+                            .map((t) => {
+                                return (
+                                    <ListItem
+                                        key={t.type}
+                                        name={t.name}
+                                        onClick={() => {
+                                            onSelect(t.type);
+                                            onClose();
+                                        }}
+                                    >
+                                        <img className="type-icon" src={getIcon(t.type)} />
+                                    </ListItem>
+                                );
                         })}
                     </div>
                 </Card>

--- a/web/src/utils/getIcon.jsx
+++ b/web/src/utils/getIcon.jsx
@@ -24,7 +24,7 @@ export const getIcon = (type) => {
     case "BLUETOOTH":
       return bluetooth;
 
-    case "FM RADIO":
+    case "FMRADIO":
       return fmradio;
 
     case "AIRPLAY":
@@ -42,7 +42,7 @@ export const getIcon = (type) => {
     case "RCA":
       return rca;
 
-    case "INTERNET RADIO":
+    case "INTERNETRADIO":
       return internetradio;
 
     case "AUX":


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR intends to hide the FM radio stream addition option when hardware is not present. This closes #631 .

It attempts to do this in a way that's relatively scalable and set us up for the future of #610 . However, `mypy` was quite displeased with my use of class variables and I couldn't make it less displeased. After spending quite some time on investigating why `__dir__()` won't show classvars, I've opted to punt on this and just wait til #610 lands (or solicit quick feedback here on being more rigorous.)
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [ ] Have you written new tests for your core features/changes, as applicable?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
