### PR TITLE
put pandora in a process monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Streams
   * Hide FM Radio if hardware is not available
   * Make pandora stream album art use HTTPS urls to make sure it is rendered in the ios app
+  * Make Pandora streams a bit more robust against failure
 
 ## 0.3.3
 * Web App

--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -723,8 +723,12 @@ class Pandora(PersistentStream):
     # start pandora process in special home
     print(f'Pianobar config at {pb_config_folder}')
     try:
+      args = [
+        f'{utils.get_folder("streams")}/process_monitor.py',
+        'pianobar'
+      ]
       self.proc = subprocess.Popen(
-        args='pianobar', stdin=subprocess.PIPE, stdout=open(pb_output_file, 'w', encoding='utf-8'),
+        args=args, stdin=subprocess.PIPE, stdout=open(pb_output_file, 'w', encoding='utf-8'),
         stderr=open(pb_error_file, 'w', encoding='utf-8'), env={'HOME': pb_home})
       time.sleep(0.1)  # Delay a bit before creating a control pipe to pianobar
       self.ctrl = pb_control_fifo
@@ -735,6 +739,7 @@ class Pandora(PersistentStream):
   def _deactivate(self):
     if self._is_running():
       self.proc.kill()
+      self.proc.wait()
     self.proc = None
     self.ctrl = ''
 


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR puts `pianobar`, our Pandora client, in a `process_monitor.py`. This fixes #570 .

It works out of the box. I've also `killall pianobar` and it did the correct thing - restarted and played music. About the only other test I'd want to do is run it for a while, but that is beginning to feel like extra credit.
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`