### PR TITLE
fix airplay album art

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * Make pandora stream album art use HTTPS urls to make sure it is rendered in the ios app
   * Make Pandora streams a bit more robust against failure
   * Fix internet radio startup bug that caused echo
+  * Fix AirPlay album art
 
 ## 0.3.3
 * Web App

--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -500,7 +500,7 @@ class AirPlay(PersistentStream):
           # if there is a title, attempt to get coverart
           images = os.listdir(self._coverart_dir)
           if len(images) > 0:
-            source.img_url = f'generated/{self.src}/{images[0]}'
+            source.img_url = f'generated/v{self.vsrc}/{images[0]}'
         else:
           source.track = "No metadata available"
 


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR fixes #651 , by correcting the URL for album art. See [here](https://github.com/micro-nova/AmpliPi/blob/550191bde660d500d177e34d60b64656f766fd50/amplipi/streams.py#L398) for the producing side of this URL.

This happened as a wombo-combo of merging the virtual sources PR into the `webapp2` branch, and the work to support airplay 2; what's interesting is that this has been busted since we launched 0.3! (Personally, I just thought it was my music client, Amperfy, doing the incorrect thing; ach so!)

Since #657 still hasn't been merged, I'm going to also roll this into 0.3.4 as a hotfix, albeit not nearly as urgent of one.
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`