### PR TITLE
Simplify release process

### DIFF
--- a/NEW_RELEASE.md
+++ b/NEW_RELEASE.md
@@ -30,10 +30,9 @@ This project follows [Semantic Versioning](https://semver.org/). Here are some e
 - [ ] Ensure the PR(s) with your features & fixes are merged into `main`.
 - [ ] Update the API by running `scripts/create_spec` script.
 - [ ] Create & merge a branch/PR off `main` to bump the version in the CHANGELOG and also using `poetry version ${VERSION}`
-- [ ] Create another branch off `main` named the version number (ie, `0.3.0`.)
+- [ ] Checkout main & create a detached HEAD: `git checkout main; git pull; git checkout --detach`
 - [ ] Build the webapp in `web` with `npm run build` and force add the changes with `git add -f web/dist; git commit -m "Build web app for release"`
 - [ ] Tag the changes so we can make a release on GitHub: `git tag -as ${VERSION} -m '' && git push origin ${VERSION}`
 - [ ] Make a release using the GitHub interface
-- [ ] Remove the branch (but not the tag) from Github, or else the ref is ambiguous to Github and the updater fails to download the right tarball.
 - [ ] Use the AmpliPi updater to update to the release
 - [ ] Test it again! If it needs changes, pull request your bugfixes against `main` and stamp a new release 😎


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR simplifies the release process. When creating this process, I had simply forgotten about detached heads; this is likely the proper way for us to create leaf refs off `main` and tag them. It also helps avoid a footrake in the prior process, where if you fail to delete the version branch AmpliPi cannot update; this obviates that.
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

