### PR TITLE
remove noisy console.log() from MenuBar

### DIFF
--- a/web/src/components/MenuBar/MenuBar.jsx
+++ b/web/src/components/MenuBar/MenuBar.jsx
@@ -45,7 +45,6 @@ const MenuBar = ({ pageNumber }) => {
     const selectedSourceId = usePersistentStore((s) => s.selectedSource);
     const selectedSource = useStatusStore(s => s.status.sources[selectedSourceId]);
     const sourceInputType = getSourceInputType(selectedSource);
-    console.log(`sourceInputType MenuBar: ${sourceInputType}`);
     const sourceIsInactive =
     sourceInputType === "none" || sourceInputType == "unknown";
   


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR removes a `console.log()` that prints a message like:
```
sourceInputType MenuBar: none MenuBar.jsx:48:12
```

every 1s in the browser. It is probably a leftover from some more active development. Explicitly not adding this change to the CHANGELOG.
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
