### PR TITLE
Update image reference in Balena Etcher flashing docs

### DIFF
--- a/docs/imaging_etcher.md
+++ b/docs/imaging_etcher.md
@@ -6,7 +6,7 @@
   * Your AmpliPi
 
 ## 1. Get the Latest AmpliPi Image
-  Download the latest AmpliPi image from [here](https://drive.google.com/file/d/1VHQhHivWCNVwmHukqtjjWu322Nxu_iDp/view) and save it to your computer.
+  Download the latest AmpliPi image from [here](https://storage.googleapis.com/amplipi-img/amplipi_0.3.1.img.xz) ([md5sum](https://storage.googleapis.com/amplipi-img/CHECKSUMS), [.sig](https://storage.googleapis.com/amplipi-img/CHECKSUMS.sig)) and save it to your computer.
 
 ## 2. Get RPIBoot
 Download and install the latest version of RPIBoot from [here](https://github.com/raspberrypi/usbboot/raw/master/win32/rpiboot_setup.exe) on windows, otherwise refer to the instructions for [building RPIBoot](https://github.com/raspberrypi/usbboot#building).


### PR DESCRIPTION
### What does this change intend to accomplish?
This updates our image reference in our Balena Etcher docs to point to our 0.3.1 image, which is the latest at the moment.
 
### Checklist

* [x] If applicable, have you updated the documentation/manual?
