### PR TITLE
Load arbitrary extra fields into /info from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Reverse order available sources are used in
 * System
   * Add version number to config
+  * Load arbitrary extra fields into /info from file
 
 ## 0.3.4
 * Web App

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -223,7 +223,8 @@ class Api:
       is_streamer=self.is_streamer,
       lms_mode=self.lms_mode,
       version=utils.detect_version(),
-      stream_types_available=amplipi.streams.stream_types_available()
+      stream_types_available=amplipi.streams.stream_types_available(),
+      extra_fields=utils.load_extra_fields()
     )
     for major, minor, ghash, dirty in self._rt.read_versions():
       fw_info = models.FirmwareInfo(version=f'{major}.{minor}', git_hash=f'{ghash:x}', git_dirty=dirty)

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -853,6 +853,7 @@ class Info(BaseModel):
   fw: List[FirmwareInfo] = Field(
     default=[], description='firmware information for each connected controller or expansion unit')
   stream_types_available: List[str] = Field(default=[], description='The stream types available on this particular appliance')
+  extra_fields: Optional[Dict] = Field(default=None, description='Optional fields for customization')
 
   class Config:
     schema_extra = {

--- a/amplipi/utils.py
+++ b/amplipi/utils.py
@@ -401,3 +401,14 @@ def set_identity(settings: Dict):
   identity.update(settings)
   with open(os.path.join(USER_CONFIG_DIR, 'identity'), encoding='utf-8', mode='w') as identity_file:
     json.dump(identity, identity_file)
+
+def load_extra_fields(filename: str = 'extra_fields.json') -> Optional[Dict]:
+  """ This function is used to scrape extra fields for 3rd party integrations from a 
+      local file on the filesystem. At present, these fields end up populating in the
+      `Info` model.
+  """
+  try:
+    with open(os.path.join(USER_CONFIG_DIR, filename), encoding='utf-8', mode='r') as extra_fields_file:
+      return json.load(extra_fields_file)
+  except Exception:
+    return None


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR permits adding arbitrary extra fields to the `/info` endpoint, loaded from a JSON file on the local filesystem. This permits some amount of third party extensibility without tighter integration.

I've tested these cases:
* valid JSON is loaded into the `/info` endpoint as expected, including non-flat structures
* invalid JSON causes the `extra_fields` key to be omitted from the endpoint
* the file not existing causes the `extra_fields` key to be omitted from the endpoint
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [ ] Have you written new tests for your core features/changes, as applicable?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
