### PR TITLE
Upgrade LMS server from 8.4.0 nightly to stable 8.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Add version number to config
   * Load arbitrary extra fields into /info from file
   * Automatically mount usb storage devices as media drives in LMS
+  * Upgrade LMS to 8.5.1
 
 ## 0.3.4
 * Web App

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -160,8 +160,8 @@ _os_deps: Dict[str, Dict[str, Any]] = {
     'apt': ['libcrypt-openssl-rsa-perl', 'libio-socket-ssl-perl'], # needed for ShairTunes2W support
     'script' : [
       'if [ ! $(dpkg-query --show --showformat=\'${Status}\' logitechmediaserver | grep -q installed) ]; then '
-      '  wget https://storage.googleapis.com/amplipi-deb/pool/main/l/logitechmediaserver/logitechmediaserver_8.4.0~1700477852_all.deb -O /tmp/logitechmediaserver_8.4.0.deb',
-      '  sudo dpkg -i /tmp/logitechmediaserver_8.4.0.deb',
+      '  wget https://storage.googleapis.com/amplipi-deb/pool/main/l/logitechmediaserver/logitechmediaserver_8.5.1_all.deb -O /tmp/logitechmediaserver_8.5.1.deb',
+      '  sudo dpkg -i /tmp/logitechmediaserver_8.5.1.deb',
       '  if [ ! -e /home/pi/.config/amplipi/lms_mode ] ; then sudo systemctl disable logitechmediaserver; fi',
       '  if [ ! -e /home/pi/.config/amplipi/lms_mode ] ; then sudo systemctl stop logitechmediaserver; fi',
       'fi',


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR upgrades the LMS server from an 8.4.x series nightly to the stable 8.5.1 release. I've tested this code and newer LMS on an AmpliPi; it works well, in particular with the newer local TiDAL and Pandora plugins that don't require mysqueezebox.com.
 
### Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] Have you written new tests for your core features/changes, as applicable?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
