### PR TITLE
Revert Pandora process_monitor.py changes from 09ca4fa, 461cd58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 * System
   * Add version number to config
   * Load arbitrary extra fields into /info from file
+  * Fix a firmware programming bug for extenders
 * LMS
   * Add metadata support
   * Add support for non-9000 ports
   * Upgrade LMS to 8.5.1
   * Automatically mount usb storage devices as media drives in LMS
+* Streams
+  * Revert recent Pandora changes for stability reasons
 
 ## 0.3.4
 * Web App

--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -728,12 +728,8 @@ class Pandora(PersistentStream):
     # start pandora process in special home
     logger.info(f'Pianobar config at {pb_config_folder}')
     try:
-      args = [
-        f'{utils.get_folder("streams")}/process_monitor.py',
-        'pianobar'
-      ]
       self.proc = subprocess.Popen(
-        args=args, stdin=subprocess.PIPE, stdout=open(pb_output_file, 'w', encoding='utf-8'),
+        args='pianobar', stdin=subprocess.PIPE, stdout=open(pb_output_file, 'w', encoding='utf-8'),
         stderr=open(pb_error_file, 'w', encoding='utf-8'), env={'HOME': pb_home})
       time.sleep(0.1)  # Delay a bit before creating a control pipe to pianobar
       self.ctrl = pb_control_fifo
@@ -748,11 +744,7 @@ class Pandora(PersistentStream):
         self.proc.wait(timeout=4)
       except:
         # Likely a subprocess.TimeoutException, but we will handle all exceptions the same.
-        # Because this runs within a process_monitor.py, we need to handle the entire
-        # process group.
-        os.killpg(self.proc.pid, signal.SIGKILL)
-        # does the child still leave a zombie if we wait() the parent? pid space is not at
-        # a premium, so I'll leave that question unanswered.
+        self.proc.kill()
         self.proc.wait()
 
     self.proc = None


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR reverts the changes from 09ca4fa, 461cd58. We suspect these have caused stability concerns (#636, #663, and [here](https://amplipi.discourse.group/t/problems-with-upgrades-to-0-3-x-errors-during-upgrade-and-no-audio/287/16).)

These changes have had seemingly limited utility, and Pandora worked well before. We stand to lose close to nothing reverting these changes.

I'm currently running this branch on an AmpliPi overnight and intend to ship it tomorrow if it works swell.
 
### Checklist

* [X] Have you tested your changes and ensured they work? (see above)
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] Have you written new tests for your core features/changes, as applicable?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
