### PR TITLE
Bump package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amplipi"
-version = "0.3.4"
+version = "0.3.5"
 description = "A Pi-based whole house audio controller"
 authors = [
   "Lincoln Lorenz <lincoln@micro-nova.com>",


### PR DESCRIPTION
### What does this change intend to accomplish?
I forgot to `poetry version 0.3.5` when pushing the prior "bump version" commit :woozy_face: 
 
