### PR TITLE
Add text wrapping to stream names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Add initial support for song browser (only Pandora stations for now)
   * Add streams to the stream list on the homepage in the order they were added
   * Add firmware version for main and expansion units on About page
+  * Limit length of displayed stream names with ellipsis
 * Streams
   * Add DLNA metadata and control support
   * Add support for browsing Pandora stations

--- a/web/src/components/Chip/Chip.jsx
+++ b/web/src/components/Chip/Chip.jsx
@@ -4,10 +4,10 @@ import PropTypes from "prop-types";
 import "./Chip.scss";
 import StopProp from "@/components/StopProp/StopProp";
 
-const Chip = ({ children, onClick }) => {
+const Chip = ({ children, onClick, style }) => {
     return (
         <StopProp>
-            <div className="chip" onClick={onClick}>
+            <div className="chip" onClick={onClick} style={style}>
                 {children}
             </div>
         </StopProp>
@@ -16,6 +16,7 @@ const Chip = ({ children, onClick }) => {
 Chip.propTypes = {
     children: PropTypes.any.isRequired,
     onClick: PropTypes.func,
+    style: PropTypes.object,
 };
 
 export default Chip;

--- a/web/src/components/StreamBadge/StreamBadge.jsx
+++ b/web/src/components/StreamBadge/StreamBadge.jsx
@@ -14,7 +14,7 @@ const StreamBadge = ({ sourceId, onClick }) => {
     const icon = getIcon(type);
 
     return (
-        <Chip onClick={onClick}>
+        <Chip onClick={onClick} style={{ maxWidth: "60vw" }}>
             <img src={icon} className="stream-badge-icon" alt="stream icon" />
             <div className="stream-badge-name">{name}</div>
         </Chip>


### PR DESCRIPTION
### What does this change intend to accomplish?
Long stream names used to overflow off of the player card and would take the close stream button with it, stream names will now wrap to avoid that issue
 
### Checklist

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] Have you written new tests for your core features/changes, as applicable?
* [x] If this is a UI change, have you tested it across multiple browser platforms?
* [x] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

