### PR TITLE
put QR code to eink display at end of mfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * API
   * Fix: Zones playing audio on source used for announcement are not muted while announcement is playing
   * Log firmware version for main and expansion units
+* Manufacturing
+  * Display a QR code to the quickstart guide for initial unboxing
 
 ## 0.3.5
 * Web App

--- a/scripts/cleanup
+++ b/scripts/cleanup
@@ -109,6 +109,9 @@ if $user_host_set; then
   ssh-keygen -f ~/.ssh/known_hosts -R $user_host
 fi
 
+echo -e "clearing & setting eink display to quickstart QR code"
+ssh $user_host "/home/pi/amplipi-dev/scripts/show-delivery-message"
+
 # shutdown amplipi
 sleep 5
 echo -e "\nLogging in to shutdown AmpliPi for shipping and remove any ssh keys"


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR puts the QR code to the e-ink display at the very end of manufacturing. This has to happen here, because earlier than this it will be overwritten, and at the end of this script the appliance is shut down and boxed up.

This closes #718 .

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] If applicable, have you updated the CHANGELOG?
