### PR TITLE
Refresh button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Add streams to the stream list on the homepage in the order they were added
   * Add firmware version for main and expansion units on About page
   * Limit length of displayed stream names with ellipsis
+  * Add restart stream button to stream player and stream modal
 * System
   * Add serial number to eink display
   * Add ability to display status on eink display

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -87,6 +87,7 @@ logger.setLevel(logging.DEBUG)
 sh = logging.StreamHandler(sys.stdout)
 logger.addHandler(sh)
 
+
 class SimplifyingRouter(APIRouter):
   """
   Overrides the route decorator logic to:
@@ -495,9 +496,11 @@ def exec_command(cmd: models.StreamCommand, ctrl: Api = Depends(get_ctrl), sid: 
     * Like/Love Current Song: **love**
     * Ban Current Song (pandora only): **ban**
     * Shelve Current Song (pandora only): **shelve**
+    * Restart Stream **restart**
 
   Supported commands are reported in an attached stream's info.stream_cmds"""
   return code_response(ctrl, ctrl.exec_stream_command(sid, cmd=cmd))
+
 
 @api.get('/api/streams/{sid}/browse', tags=['stream'])
 def browse_stream(ctrl: Api = Depends(get_ctrl), sid: int = params.StreamID) -> models.BrowsableItemResponse:
@@ -512,7 +515,7 @@ def browse_stream(ctrl: Api = Depends(get_ctrl), sid: int = params.StreamID) -> 
 
 
 @api.get('/api/streams/{sid}/{pid}/browse', tags=['stream'])
-def browse_stream_child(ctrl: Api = Depends(get_ctrl), sid: int = params.StreamID, pid : int = params.ParentID) -> models.BrowsableItemResponse:
+def browse_stream_child(ctrl: Api = Depends(get_ctrl), sid: int = params.StreamID, pid: int = params.ParentID) -> models.BrowsableItemResponse:
   """ Browse the children of a media item in the current stream """
   stream = ctrl.streams[sid]
   if stream is None:
@@ -522,8 +525,9 @@ def browse_stream_child(ctrl: Api = Depends(get_ctrl), sid: int = params.StreamI
 
   return models.BrowsableItemResponse(items=stream.browse(parent=pid))
 
+
 @api.get('/api/streams/{sid}/{cid}/play', tags=['stream'])
-def play_stream_child(ctrl: Api = Depends(get_ctrl), sid: int = params.StreamID, cid : int = params.ChildID) -> models.Status:
+def play_stream_child(ctrl: Api = Depends(get_ctrl), sid: int = params.StreamID, cid: int = params.ChildID) -> models.Status:
   """ Play a child item from the current stream """
   stream = ctrl.streams[sid]
   if stream is None:

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -1068,6 +1068,8 @@ class Api:
             stream.activate()
           else:
             stream.deactivate()
+      elif cmd in ['restart']:
+        stream.restart()
       else:
         stream.send_cmd(cmd)
     except Exception as exc:

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -797,6 +797,7 @@ class StreamCommand(str, Enum):
   SHELVE = 'shelve'
   ACTIVATE = 'activate'
   DEACTIVATE = 'deactivate'
+  RESTART = 'restart'
 
 
 class PresetState(BaseModel):
@@ -1093,8 +1094,8 @@ class Status(BaseModel):
                                   'name': 'Blackmill Radio - pandora',
                                   'state': 'playing',
                                   'station': 'Blackmill Radio',
-                                  'supported_cmds': ['play', 'pause', 'stop', 'next',
-                                                     'love', 'ban', 'shelve'],
+                                  '': ['play', 'pause', 'stop', 'next',
+                                       'love', 'ban', 'shelve', 'restart'],
                                   'track': 'Chambermaid Swing'},
                          'input': 'stream=1006',
                          'name': 'Input 3'},
@@ -1106,7 +1107,7 @@ class Status(BaseModel):
                                   'state': 'playing',
                                   'station': 'Antonio Vivaldi Radio',
                                   'supported_cmds': ['play', 'pause', 'stop', 'next',
-                                                     'love', 'ban', 'shelve'],
+                                                     'love', 'ban', 'shelve', 'restart'],
                                   'track': 'Nocturne For Piano In C Sharp Minor, Kk '
                                   'Anh.ia/6'},
                          'input': 'stream=1005',

--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -139,6 +139,17 @@ class BaseStream:
     self.state = 'connected'
     self.src = src
 
+  def restart(self):
+    """Reset this stream by disconnecting and reconnecting"""
+    try:
+      self.send_cmd('stop')
+    except:
+      logger.info(f'Stream {self.name} does not have a stop response')
+    last_src = self.src # Disconnect sets self.src to none, so temp variable used to keep track
+    self.disconnect()
+    time.sleep(0.1)
+    self.connect(last_src)
+
   def is_connected(self) -> bool:
     return self.src is not None
 
@@ -283,6 +294,16 @@ class PersistentStream(BaseStream):
     if self.is_activated():
       self.deactivate()
       time.sleep(0.1)  # wait a bit just in case
+
+  def restart(self):
+    """Reset this stream by disconnecting and reconnecting"""
+    try:
+      self.send_cmd('stop')
+    except:
+      logger.info(f'Stream {self.name} does not have a stop response')
+    self.deactivate()
+    time.sleep(0.1)
+    self.activate()
 
   def connect(self, src: int):
     """ Connect an output to a given audio source """

--- a/web/src/pages/Settings/Streams/StreamModal/StreamModal.jsx
+++ b/web/src/pages/Settings/Streams/StreamModal/StreamModal.jsx
@@ -10,6 +10,7 @@ import ModalCard from "@/components/ModalCard/ModalCard";
 const NAME_DESC =
   "This name can be anything - it will be used to select this stream from the source selection dropdown";
 const DISABLED_DESC = "Don't show this stream in the input dropdown";
+const RESTART_DESC = "Sometimes the stream gets into a bad state and neds to be restarted. If that happened to this stream, click this to restart the stream.";
 
 // We're already using mui, why are we reinventing the wheel? https://mui.com/material-ui/react-text-field/
 // if it's a matter of className control on the underlying components, that still works with the mui textfield with the InputLabelProps prop and other componentProps
@@ -64,6 +65,25 @@ BoolField.propTypes = {
     desc: PropTypes.string.isRequired,
     defaultValue: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
+};
+
+const ButtonField = ({ name, text, onClick, desc }) => {
+    return (
+        <>
+            <div className="stream-field-button">
+                <div className="stream-field-name">{name}</div>
+                <button onClick={onClick == undefined ? () => {} : onClick}>{text}</button>
+            </div>
+            <div className="stream-field-desc">{desc}</div>
+            <Divider />
+        </>
+    );
+};
+ButtonField.propTypes = {
+    name: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    desc: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
 };
 
 const InternetRadioSearch = ({ onChange }) => {
@@ -134,7 +154,7 @@ InternetRadioSearch.propTypes = {
 };
 
 function validateInput(streamFields, streamTemplate) {
-    streamTemplate['fields'].filter((f) => f.required).map( (f) => {
+    streamTemplate["fields"].filter((f) => f.required).map( (f) => {
         if(!streamFields[f.name]) {
             throw new Error(`Required field not set: ${f.name}`);
         }
@@ -144,7 +164,7 @@ function validateInput(streamFields, streamTemplate) {
 validateInput.propTypes = {
     streamFields: PropTypes.object.isRequired,
     streamTemplate: PropTypes.object.isRequired,
-}
+};
 
 const StreamModal = ({ stream, onClose, apply, del }) => {
     const [streamFields, setStreamFields] = React.useState(
@@ -239,7 +259,16 @@ const StreamModal = ({ stream, onClose, apply, del }) => {
                         setStreamFields({ ...streamFields, disabled: v });
                     }}
                 />
-            { errorMessage && <Alert severity="error" variant="filled">{errorMessage}</Alert>}
+
+                <ButtonField
+                    name="Restart"
+                    text="Restart Stream"
+                    desc={RESTART_DESC}
+                    onClick={() => fetch("/api/streams/" + stream.id + "/restart",{
+                        method: "POST"
+                    })}
+                />
+                { errorMessage && <Alert severity="error" variant="filled">{errorMessage}</Alert>}
             </div>
         </ModalCard>
     );

--- a/web/src/pages/Settings/Streams/StreamModal/StreamModal.scss
+++ b/web/src/pages/Settings/Streams/StreamModal/StreamModal.scss
@@ -21,6 +21,12 @@
   align-items: center;
 }
 
+.stream-field-button {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 .stream-field-name {
   @include general.regular-font;
   color: general.$text-color;


### PR DESCRIPTION
### What does this change intend to accomplish?
There was no easy way to reset a broken stream before. This adds a button to the player view and the modal in settings to do that. The buttons interface with a stream command on the REST API that resets a stream. IT supports both BaseStream and PersistentStream.

### Checklist

* [X] Have you tested your changes and ensured they work?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [X] If applicable, have you updated the CHANGELOG?
* [X] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms?
* [X] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

Web View:
![reset0](https://github.com/micro-nova/AmpliPi/assets/109907417/7832b8e3-dc28-4e25-a4e9-449f147f3693)

iPad:
![reset_ipad](https://github.com/micro-nova/AmpliPi/assets/109907417/4d56e79d-4e23-4219-97ac-2c41ba371ae2)

iPhone 12 Mini:
![reset_iphone12mini](https://github.com/micro-nova/AmpliPi/assets/109907417/a703db04-5b8a-4480-b5e8-57ec1d17cfe3)

iPhone SE
![reset_iphonese](https://github.com/micro-nova/AmpliPi/assets/109907417/692fba15-6234-4d6a-9c6f-4fdddf520875)

Stream Modal:
![reset_modal](https://github.com/micro-nova/AmpliPi/assets/109907417/11b1a9bd-036c-404e-954f-5d3fae4bcdc2)
