### PR TITLE
Better logging during failed installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * System
   * Add serial number to eink display
   * Add ability to display status on eink display
+  * Better logging around failed upgrades
 * Display
   * Add serial number
   * Add status code field

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -925,6 +925,7 @@ def install(os_deps=True, python_deps=True, web=True, restart_updater=False,
   def failed():
     for task in tasks:
       if not task.success:
+        print(str(task)) # __str__() on Task renders with an "Error"ed suffix
         return True
     return False
 


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR adds logging for failed tasks, such that they are explicitly mentioned in the logs instead of implicitly reported. This will help illuminate #669 (which I've also seen intermittently and didn't have enough information to debug), though it will not solve it.

I tested this by briefly deploying using `./scripts/deploy` a `configure.py` that included a non-existent apt package; it appropriately reported the errored task:

```
install debian packages : [['sudo', 'apt-get', 'install', '-y', 'pianobar', 'vlc', 'uuid-runtime', 'doesnt-exist', 'automake', 'gst
reamer1.0-plugins-bad', 'build-essential', 'gstreamer1.0-plugins-base', 'rtl-sdr', 'python3-pip', 'jq', 'm4', 'libsndfile1-dev', 'a
uthbind', 'gstreamer1.0-plugins-ugly', 'python-dbus', 'libtool', 'libcrypt-openssl-rsa-perl', 'git', 'gstreamer1.0-libav', 'libliqu
id-dev', 'gstreamer1.0-alsa', 'shairport-sync', 'gstreamer1.0-plugins-good', 'libopenjp2-7', 'autotools-dev', 'libgstreamer1.0-dev'
, 'curl', 'pkg-config', 'stm32flash', 'systemd-journal-remote', 'libasound2-dev', 'libbluetooth-dev', 'autoconf', 'libio-socket-ssl
-perl', 'libupnp-dev', 'libsndfile1', 'libatlas-base-dev', 'python3-venv', 'libgirepository1.0-dev', 'xkcdpass', 'python3-pil', 'li
bcairo2-dev', 'bluealsa']]
  Reading package lists...
  Building dependency tree...
  Reading state information...
  E: Unable to locate package doesnt-exist
  Error: Task Failed
  OS dependency install step failed, exiting...
```

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
