### PR TITLE
Added an expiration time to display status related to expanders

### DIFF
--- a/amplipi/display/common.py
+++ b/amplipi/display/common.py
@@ -143,14 +143,14 @@ def get_num_expanders(url: str) -> int:
       if info is not None:
         return len(info.expanders)
       else:
-        set_custom_display_status(DisplayStatus(DisplayError.API_NO_EXPANDER, None))
+        set_custom_display_status(DisplayStatus(int(DisplayError.API_NO_EXPANDER)))
         return 0
     else:
-      set_custom_display_status(DisplayStatus(DisplayError.API_NO_EXPANDER, None))
+      set_custom_display_status(DisplayStatus(int(DisplayError.API_NO_EXPANDER)))
       return 0
   except Exception as e:
     log.error(f'Error getting number of expanders: {type(e).__name__}')
-    set_custom_display_status(DisplayStatus(DisplayError.EXPANDER_EXCEPTION, None))
+    set_custom_display_status(DisplayStatus(int(DisplayError.EXPANDER_EXCEPTION)))
     return 0
 
 
@@ -165,8 +165,8 @@ def get_status(url: str, no_serial_ok: bool = False) -> Tuple[Union[str, int], O
     result_status = st
 
   # Check if API is running
-  api_on = os.system("systemctl --user is-active amplipi.service")
-  if api_on != 0:
+  api_on = subprocess.run("systemctl --user is-active amplipi.service".split(), stdout=subprocess.DEVNULL)
+  if api_on.returncode != 0:
     return DisplayError.NO_AMPLIPI_SERVICE, None, 0
 
   if url is None:

--- a/amplipi/display/statusinterface.py
+++ b/amplipi/display/statusinterface.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Display Status Interface"""
 
+import datetime
+
 from loguru import logger as log
-from datetime import datetime
 from typing import Optional, Union
 from enum import IntEnum
 
@@ -11,10 +12,14 @@ STATUS_FILENAME = 'display-status.txt'
 
 
 class DisplayStatus:
-  status: Optional[Union[str, int]]  # Status as either a string (working normally) or int (error)
-  expiration: Optional[datetime] = None  # When this status is set to expire
+   # Status as either a string (working normally) or int (error)
+  status: Optional[Union[str, int]]
 
-  def __init__(self, status: Optional[Union[str, int]], expiration: Optional[datetime] = None):
+  # When this status is set to expire, default is 10 seconds
+  expiration: Optional[datetime.datetime]
+
+  def __init__(self, status: Optional[Union[str, int]], expiration: Optional[datetime.datetime] =
+               datetime.datetime.now() + datetime.timedelta(seconds=10)):
     self.status = status
     self.expiration = expiration
 


### PR DESCRIPTION
### What does this change intend to accomplish?
There was a bug on the display where some statuses would not clear when the underlying issue stopped, particularly when calculating the number of expanders. To fix that, I added an expiration time of 10 seconds.

### Checklist

* [X] Have you tested your changes and ensured they work?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* 
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
