### PR TITLE
clean up LMS client termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * Add DLNA metadata and control support
   * Add support for browsing Pandora stations
   * Make Pandora like work and pass tests without metadata race condition
+  * Handle LMS client cleanup better
 * API
   * Fix: Zones playing audio on source used for announcement are not muted while announcement is playing
   * Log firmware version for main and expansion units


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR makes the LMS client termination code way cleaner and more straightforward. Prior, if the metaproc handling exceptioned, only the main proc would get fully killed. This change properly splits out that logic. 

This change was spurred by reexamining stuff related to #702 ; after running this branch for 5 days, I am unable to replicate that particular issue. It's hard to say if that means I didn't replicate it, or this fixed it. My gut feeling is that this isn't the fix for that issue and I'll keep trying to replicate it, but in the meantime this is still a valid fix.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
