### PR TITLE
Kick disabled zones and hide disabled groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
   * Fix broken API generation
 * Web App
   * Enforce breakpoint styling to ensure that the UI looks the same between mobile, desktop, tablet viewports
+  * Groups containing disabled zones now behave as though those zones don't exist
+  * Groups containing only disabled zones no longer selectable
 * Streams
   * Remove stop command (only accessable through API) from Pandora
+  * Disconnect zones from sources when they are disabled
 
 ## 0.3.6
 * Web App

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -756,6 +756,11 @@ class Api:
         # parse and check the source id
         sid = utils.parse_int(source_id, range(models.SOURCE_DISCONNECTED, models.MAX_SOURCES))
 
+        # disconnect zone from source if it's disabled.
+        if zone.disabled:
+          sid = models.SOURCE_DISCONNECTED
+          update_source_id = True
+
         # any zone disabled by source disconnection or a 'disabled' flag should not be able to play anything
         implicit_mute = zone.disabled or sid == models.SOURCE_DISCONNECTED
         if implicit_mute and not mute:
@@ -870,6 +875,10 @@ class Api:
     """Updates the group's aggregate fields to maintain consistency and simplify app interface"""
     for group in self.status.groups:
       zones = [self.status.zones[z] for z in group.zones]
+
+      # remove disabled from further calculations
+      zones = [z for z in zones if not z.disabled]
+
       mutes = [z.mute for z in zones]
       sources = {z.source_id for z in zones}
       vols = [z.vol_f for z in zones]

--- a/web/src/components/ZonesModal/ZonesModal.jsx
+++ b/web/src/components/ZonesModal/ZonesModal.jsx
@@ -47,12 +47,22 @@ const ZonesModal = ({
     const zones = useStatusStore
         .getState()
         .status.zones.filter((zone) => !zone.disabled);
-    const groups = useStatusStore.getState().status.groups;
+
+    const disabled_zone_ids = useStatusStore
+        .getState()
+        .status.zones.filter((zone) => zone.disabled).map((z => z.id));
+
+
+    const groups = useStatusStore.getState().status.groups.filter((group) =>
+        group.zones.some((zone) => (zones.map((z) => z.id).includes(zone)))
+    );
+
     const [checkedZonesIds, setCheckedZoneIds] = useState(
         zones
             .filter((zone) => zone.source_id === sourceId && loadZonesGroups)
             .map((zone) => zone.id)
     );
+
     const [checkedGroupIds, setCheckedGroupIds] = useState(
         groups
             .filter((group) => group.source_id === sourceId && loadZonesGroups)
@@ -61,7 +71,12 @@ const ZonesModal = ({
 
     const computeCheckedGroups = (newCheckedZonesIds) => {
         const newGroups = groups
-            .filter((g) => g.zones.every((id) => newCheckedZonesIds.includes(id)))
+            .filter((g) => g.zones.every((id) => {
+                if (disabled_zone_ids.find((d_id) => id === d_id)) {
+                    return true;
+                }
+                return newCheckedZonesIds.includes(id);
+            }))
             .map((g) => g.id);
         setCheckedGroupIds(newGroups);
     };

--- a/web/src/utils/GroupZoneFiltering.jsx
+++ b/web/src/utils/GroupZoneFiltering.jsx
@@ -38,13 +38,11 @@ export const getFittestGroups = (zones, groups) => {
     let best = [];
     for (const group of groups) {
         let fitness = groupZoneMatchCount(zones, group);
-        if (groupIsSubset(group, zones)) {
-            if (fitness > bestFitness) {
-                bestFitness = fitness;
-                best = [group];
-            } else if (fitness == bestFitness) {
-                best.push(group);
-            }
+        if (fitness > bestFitness) {
+            bestFitness = fitness;
+            best = [group];
+        } else if (fitness == bestFitness) {
+            best.push(group);
         }
     }
 


### PR DESCRIPTION
### What does this change intend to accomplish?
Kicks zones that have been disabled off of their sources since right now they get stuck with no way to add or remove them from their source. Also hides groups where all zones have been disabled, and treats the remaining zones of a group as if they were the only ones if only a few of the zones were disabled.

### Checklist

* [X] Have you tested your changes and ensured they work?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
