### PR TITLE
Make upgrades a bit more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Add serial number to eink display
   * Add ability to display status on eink display
   * Better logging around failed upgrades
+  * Make upgrades more stable
 * Display
   * Add serial number
   * Add status code field

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -606,7 +606,7 @@ def _start_restart_service(name: str, restart: bool, test_url: Union[None, str] 
   # wait a bit, so initial failures are detected before is-active is called
   if tasks[-1].success:
     # we need to check if the service is running
-    for _ in range(25): # retry for 5 seconds, giving the service time to start
+    for _ in range(50): # retry for 10 seconds, giving the service time to start
       task_check, running = _service_status(service)
       if running:
         break
@@ -614,7 +614,7 @@ def _start_restart_service(name: str, restart: bool, test_url: Union[None, str] 
     tasks += task_check
     if test_url and running:
       task = None
-      for _ in range(40): # retry for 20 seconds, giving the server time to start
+      for _ in range(60): # retry for 30 seconds, giving the server time to start
         task = _check_url(test_url)
         if task.success:
           break


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR increases the service restart retrying period during upgrades. I've seen this fail a couple of times when it shouldn't have (the service eventually restarted, but wasn't up within the 5s/20s); I also know I've personally added some ['lengthy' hardware checks](https://github.com/micro-nova/AmpliPi/pull/646/files#diff-b099f52a8996d7f5e64a578e2d43f942e75b5c095abacae37278e5c1af448577R1236) over time that probably make this more necessary, in addition to our software simply becoming more complex.

I don't feel like our service increasing startup time from & to these values is massively problematic. We're working towards getting newer Python which should increase our startup speed a ton; this is a decent change in the interim to increase 'stability' of upgrades, without necessarily kicking some performance can down the road ceaselessly.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
