### PR TITLE
Upgrade LMS to 8.5.2, Squeezelite to 2.0.0-1488+git20240509.0e85ddf-1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   * Better logging around failed upgrades
   * Make upgrades more stable
   * Implement opt-in remote support capabilities from the updater
+  * Upgrade LMS (Lyrion Media Server, formerly Logitech Media Server)
 * Display
   * Add serial number
   * Add status code field
@@ -29,6 +30,7 @@
   * Add support for browsing Pandora stations
   * Make Pandora like work and pass tests without metadata race condition
   * Handle LMS client cleanup better
+  * Upgrade LMS client, squeezelite
 * API
   * Fix: Zones playing audio on source used for announcement are not muted while announcement is playing
   * Log firmware version for main and expansion units

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -194,17 +194,17 @@ _os_deps: Dict[str, Dict[str, Any]] = {
     ]
   },
   'lms' : {
-    'apt': ['libcrypt-openssl-rsa-perl', 'libio-socket-ssl-perl'], # needed for ShairTunes2W support
+    'apt': ['libcrypt-openssl-rsa-perl', 'libio-socket-ssl-perl', 'libopusfile0'],
     'copy' : [{'from': 'bin/ARCH/find_lms_server', 'to': 'streams/find_lms_server'}],
     'script' : [
       'if [ ! $(dpkg-query --show --showformat=\'${Status}\' logitechmediaserver | grep -q installed) ]; then '
-      '  wget https://storage.googleapis.com/amplipi-deb/pool/main/l/logitechmediaserver/logitechmediaserver_8.5.1_all.deb -O /tmp/logitechmediaserver_8.5.1.deb',
-      '  sudo dpkg -i /tmp/logitechmediaserver_8.5.1.deb',
+      '  wget -nv https://storage.googleapis.com/amplipi-deb/pool/main/l/logitechmediaserver/logitechmediaserver_8.5.2_all.deb -O /tmp/logitechmediaserver_8.5.2.deb',
+      '  sudo dpkg -i /tmp/logitechmediaserver_8.5.2.deb',
       '  if [ ! -e /home/pi/.config/amplipi/lms_mode ] ; then sudo systemctl disable logitechmediaserver; fi',
       '  if [ ! -e /home/pi/.config/amplipi/lms_mode ] ; then sudo systemctl stop logitechmediaserver; fi',
       'fi',
-      'wget https://storage.googleapis.com/amplipi-deb/pool/main/s/squeezelite/squeezelite_1.9.9-1449_armhf.deb -O /tmp/squeezelite_1.9.9-1449_armhf.deb',
-      'sudo dpkg -i /tmp/squeezelite_1.9.9-1449_armhf.deb',
+      'wget -nv https://storage.googleapis.com/amplipi-deb/pool/main/s/squeezelite/squeezelite_2.0.0-1488+git20240509.0e85ddf-1.1_armhf.deb -O /tmp/squeezelite_2.0.0-1488+git20240509.0e85ddf-1.1_armhf.deb',
+      'sudo dpkg -i /tmp/squeezelite_2.0.0-1488+git20240509.0e85ddf-1.1_armhf.deb',
       'sudo systemctl stop squeezelite',
       'sudo systemctl disable squeezelite',
 


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR upgrades LMS to 8.5.2, and Squeezelite to 2.0.0-1488+git20240509.0e85ddf-1.1. This is a bit of a Hail Mary for #702 . I backported a source squeezelite from upstream trixie and compiled according to [our instructions](https://github.com/micro-nova/micronova-packages); the LMS .deb comes from [the project upstream](https://lyrion.org/downloads/).

Filing this as a draft right now, because I'm running this on `gramplipi` at least overnight to ensure stability. 

### Checklist

* [ ] Have you tested your changes and ensured they work?
* [ ] If applicable, have you updated the CHANGELOG?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
