### PR TITLE
tweaks for continuous integration runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming Release
 * System
   * Fix broken API generation
+  * Permit continuous integration runs in the installer for automated disk image builds
 * Web App
   * Enforce breakpoint styling to ensure that the UI looks the same between mobile, desktop, tablet viewports
   * Groups containing disabled zones now behave as though those zones don't exist
@@ -13,7 +14,7 @@
 * Streams
   * Remove stop command (only accessable through API) from Pandora
   * Disconnect zones from sources when they are disabled
-* Updated Pianobar to fork of 2022.04.01
+  * Updated Pianobar to fork of 2022.04.01
 
 ## 0.3.6
 * Web App


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR contains tweaks that permit running `./scripts/configure.py` (our installer) during continuous integration. This is foundational work for #471 , and in my test case produces an image now. It also runs cleanly against my test case AmpliPro Streamer on my desk.

I'm iterating on this a bit still, but I'm opening a draft PR now for any feedback.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`