### PR TITLE
update available badge on both MenuBar and Settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Minor security increase to Pandora passwords
   * Add restart stream button to stream player and stream modal
   * Add dynamic scaling to controls on Player page
+  * Make update available badge show up on both Settings page and the menu bar
 * System
   * Add serial number to eink display
   * Add ability to display status on eink display

--- a/web/src/components/MenuBar/MenuBar.jsx
+++ b/web/src/components/MenuBar/MenuBar.jsx
@@ -11,6 +11,7 @@ import Badge from "@mui/material/Badge";
 import { useStatusStore, usePersistentStore } from "@/App";
 import { getSourceInputType } from "@/utils/getSourceInputType";
 import { router } from "@/main";
+import { updateAvailable } from "@/utils/updateAvailable";
 
 import PropTypes from "prop-types";
 
@@ -31,16 +32,6 @@ const MenuBar = ({ pageNumber }) => {
             break;
         }
     };
-
-    const updateAvailable = useStatusStore(
-        (s) =>
-            s.status.info.version
-                .split("+")[0]
-                .localeCompare(s.status.info.latest_release, undefined, {
-                    numeric: true,
-                    sensitivity: "base",
-                }) < 0
-    );
 
     const selectedSourceId = usePersistentStore((s) => s.selectedSource);
     const selectedSource = useStatusStore(s => s.status.sources[selectedSourceId]);
@@ -67,7 +58,7 @@ const MenuBar = ({ pageNumber }) => {
                 <BottomNavigationAction
                     label="Settings"
                     icon={
-                        <Badge badgeContent={updateAvailable ? " " : null} color="primary">
+                        <Badge badgeContent={updateAvailable() ? " " : null} color="primary">
                             <SettingsIcon />
                         </Badge>
                     }

--- a/web/src/pages/Settings/Settings.jsx
+++ b/web/src/pages/Settings/Settings.jsx
@@ -10,6 +10,7 @@ import Config from "./Config/Config";
 import About from "./About/About";
 import { router } from "@/main";
 import { useStatusStore } from "@/App";
+import { updateAvailable } from "@/utils/updateAvailable";
 // import Divider from "@mui/material/Divider";
 import SpeakerIcon from "@mui/icons-material/Speaker";
 import SpeakerGroupIcon from "@mui/icons-material/SpeakerGroup";
@@ -21,6 +22,7 @@ import PlaylistAddIcon from "@mui/icons-material/PlaylistAdd";
 import ListItem from "@/components/List/ListItem/ListItem";
 import List from "@/components/List/List";
 import { IsMobileApp, IsSaved, SaveURL, UnsaveURL } from "@/utils/MobileApp";
+import Badge from "@mui/material/Badge";
 
 import PropTypes from "prop-types";
 import Checkbox from "@mui/material/Checkbox";
@@ -160,7 +162,9 @@ const Settings = ({ openPage }) => {
                         }}
                     >
                         <div className="update-icon">
-                            <UpdateIcon fontSize="inherit" />
+                            <Badge badgeContent={updateAvailable() ? " " : null} color="primary">
+                                <UpdateIcon fontSize="inherit" />
+                            </Badge>
                         </div>
                     </ListItem>
 

--- a/web/src/utils/updateAvailable.jsx
+++ b/web/src/utils/updateAvailable.jsx
@@ -1,0 +1,12 @@
+import { useStatusStore } from "@/App";
+
+export function updateAvailable() {
+    return useStatusStore( (s) =>
+        s.status.info.version
+            .split("+")[0]
+            .localeCompare(s.status.info.latest_release, undefined, {
+                numeric: true,
+                sensitivity: "base",
+            }) < 0 
+    );
+};


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR makes the "update available" badge appear on both the menubar and the settings page. It shows up when there's an update; it doesn't show up when one is on the latest & greatest.

This closes #607 .

![Screenshot from 2024-06-13 11-12-11](https://github.com/micro-nova/AmpliPi/assets/7657783/46ddc4ef-c1f4-4d05-8d76-a5e1c3fd7673)


### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms? Firefox & Chromium
* [x] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)? phone & desktop

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
