### PR TITLE
Player No-Zone obviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Add dynamic scaling to controls on Player page
   * Make update available badge show up on both Settings page and the menu bar
   * Fix stream icons
+  * Make it clearer when a stream needs a zone added on the home screen
 * System
   * Add serial number to eink display
   * Add ability to display status on eink display

--- a/web/src/components/Chip/Chip.jsx
+++ b/web/src/components/Chip/Chip.jsx
@@ -4,10 +4,10 @@ import PropTypes from "prop-types";
 import "./Chip.scss";
 import StopProp from "@/components/StopProp/StopProp";
 
-const Chip = ({ children, onClick, style, pulse}) => {
+const Chip = ({ children, onClick, style, shake}) => {
     let className = "chip"
-    if(pulse){
-        className += " pulse"
+    if(shake){
+        className += " shake"
     }
     return (
         <StopProp>

--- a/web/src/components/Chip/Chip.jsx
+++ b/web/src/components/Chip/Chip.jsx
@@ -4,10 +4,14 @@ import PropTypes from "prop-types";
 import "./Chip.scss";
 import StopProp from "@/components/StopProp/StopProp";
 
-const Chip = ({ children, onClick, style }) => {
+const Chip = ({ children, onClick, style, pulse}) => {
+    let className = "chip"
+    if(pulse){
+        className += " pulse"
+    }
     return (
         <StopProp>
-            <div className="chip" onClick={onClick} style={style}>
+            <div className={className} onClick={onClick} style={style}>
                 {children}
             </div>
         </StopProp>
@@ -17,6 +21,7 @@ Chip.propTypes = {
     children: PropTypes.any.isRequired,
     onClick: PropTypes.func,
     style: PropTypes.object,
+    pulse: PropTypes.bool,
 };
 
 export default Chip;

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -1,5 +1,11 @@
 @use "src/general";
 
+:root {
+  --start-shadow: 0px 0px 25px 0px rgba(0, 0, 0, 1);
+  --pulse-shadow: 0px 0px 25px 3px rgba(0, 149, 255, 1);
+}
+
+
 .chip {
   display: flex;
   align-items: center;
@@ -12,15 +18,25 @@
 
 
 @keyframes pulseBackground {
-  0%{
-    background-color: #1a1a1aa6;
+  // Do not edit the steps of this animation unless you intend to not use box-shadow
+  // Update the variables inside of :root at the top of the file instead
+
+  0%{ // Start
+    box-shadow: var(--start-shadow);
   }
 
-  50%{
-    background-color: #5d5d5daa;
+  15%{ // Pulse 1
+    box-shadow: var(--pulse-shadow);
   }
-  100%{
-    background-color: #1a1a1aa6;
+  30%{ // Recover 1
+    box-shadow: var(--start-shadow);
+  }
+
+  45%{ // Pulse 2
+    box-shadow: var(--pulse-shadow);
+  }
+  60%{ // Recover 2
+    box-shadow: var(--start-shadow);
   }
 }
 

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -11,35 +11,31 @@
 }
 
 
-@keyframes pulseBackground {
+@keyframes shakeBackground {
   // Do not edit the steps of this animation unless you intend to not use box-shadow
-  // Update the variables inside of .pulse at the bottom of the file instead
+  // Update the variables inside of .shake at the bottom of the file instead
 
   0%{ // Start
-    box-shadow: var(--start-shadow);
+    transform: var(--left);
   }
 
-  15%{ // Pulse 1
-    box-shadow: var(--pulse-shadow);
+  3%{ // Shake 1
+    transform: var(--right);
   }
-  30%{ // Recover 1
-    box-shadow: var(--start-shadow);
-  }
-
-  45%{ // Pulse 2
-    box-shadow: var(--pulse-shadow);
-  }
-  60%{ // Recover 2
-    box-shadow: var(--start-shadow);
+  6%{ // Reset 1
+    transform: var(--left);
   }
 
-  100%{ // End
-    box-shadow: var(--start-shadow);
+  9%{ // Shake 2
+    transform: var(--right);
+  }
+  12%{ // Reset 2
+    transform: var(--left);
   }
 }
 
-.pulse {
-  --start-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.5);
-  --pulse-shadow: 0px 0px 10px 0px rgba(0, 149, 255, 1);
-  animation: pulseBackground 2s infinite;
+.shake {
+  --left: translate(0px, 0px);
+  --right: translate(5px, 0px);
+  animation: shakeBackground 4s infinite;
 }

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -32,6 +32,10 @@
   60%{ // Recover 2
     box-shadow: var(--start-shadow);
   }
+
+  100%{ // End
+    box-shadow: var(--start-shadow);
+  }
 }
 
 .pulse {

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -11,9 +11,14 @@
 }
 
 
-@keyframes shakeBackground {
-  // Do not edit the steps of this animation unless you intend to not use box-shadow
+@keyframes shakeComponent {
+  // Shakes a component. Used to draw attention to the add zones button when there are no zones connnected to a source
+  // We've tried animations that change the color and opacity of the background, and animations that change the size and color of the shadow
+  // We landed on a shake to provide accessibility to the color blind
+
+  // Do not edit the steps of this animation unless you intend to not use translate
   // Update the variables inside of .shake at the bottom of the file instead
+  // The prime directive when changing this is to have something that draws attention, but doesn't demand it; Don't overdo the animation.
 
   0%{ // Start
     transform: var(--left);
@@ -37,5 +42,5 @@
 .shake {
   --left: translate(0px, 0px);
   --right: translate(5px, 0px);
-  animation: shakeBackground 4s infinite;
+  animation: shakeComponent 4s infinite;
 }

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -37,5 +37,5 @@
 .pulse {
   --start-shadow: 0px 0px 25px 0px rgba(0, 0, 0, 1);
   --pulse-shadow: 0px 0px 25px 3px rgba(0, 149, 255, 1);
-  animation: pulseBackground 3s infinite;
+  animation: pulseBackground 4s infinite;
 }

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -13,14 +13,14 @@
 
 @keyframes pulseBackground {
   0%{
-    background-color: rgba(26, 26, 26, 1);
+    background-color: #1a1a1aa6;
   }
 
   50%{
-    background-color: rgba(26, 26, 26, 0.6590803922);
+    background-color: #1a1a1aff;
   }
   100%{
-    background-color: rgba(26, 26, 26, 1);
+    background-color: #1a1a1aa6;
   }
 }
 

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -1,11 +1,5 @@
 @use "src/general";
 
-:root {
-  --start-shadow: 0px 0px 25px 0px rgba(0, 0, 0, 1);
-  --pulse-shadow: 0px 0px 25px 3px rgba(0, 149, 255, 1);
-}
-
-
 .chip {
   display: flex;
   align-items: center;
@@ -19,7 +13,7 @@
 
 @keyframes pulseBackground {
   // Do not edit the steps of this animation unless you intend to not use box-shadow
-  // Update the variables inside of :root at the top of the file instead
+  // Update the variables inside of .pulse at the bottom of the file instead
 
   0%{ // Start
     box-shadow: var(--start-shadow);
@@ -41,5 +35,7 @@
 }
 
 .pulse {
+  --start-shadow: 0px 0px 25px 0px rgba(0, 0, 0, 1);
+  --pulse-shadow: 0px 0px 25px 3px rgba(0, 149, 255, 1);
   animation: pulseBackground 3s infinite;
 }

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -39,7 +39,7 @@
 }
 
 .pulse {
-  --start-shadow: 0px 0px 25px 0px rgba(0, 0, 0, 1);
-  --pulse-shadow: 0px 0px 25px 3px rgba(0, 149, 255, 1);
-  animation: pulseBackground 4s infinite;
+  --start-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.5);
+  --pulse-shadow: 0px 0px 10px 0px rgba(0, 149, 255, 1);
+  animation: pulseBackground 2s infinite;
 }

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -9,3 +9,21 @@
   margin: 0.25rem;
   @include general.highlight-hover;
 }
+
+
+@keyframes pulseBackground {
+  0%{
+    background-color: rgba(26, 26, 26, 1);
+  }
+
+  50%{
+    background-color: rgba(26, 26, 26, 0.6590803922);
+  }
+  100%{
+    background-color: rgba(26, 26, 26, 1);
+  }
+}
+
+.pulse {
+  animation: pulseBackground 3s infinite;
+}

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -37,6 +37,10 @@
   12%{ // Reset 2
     transform: var(--left);
   }
+
+  // Because the animation ends on the same phase it begins, there is no need to have anything between 12-100%.
+  // In some animations this is not the case, but due to it being a simple translation there is no issue with snapping back
+  // into the original postion on animation restart
 }
 
 .shake {

--- a/web/src/components/Chip/Chip.scss
+++ b/web/src/components/Chip/Chip.scss
@@ -17,7 +17,7 @@
   }
 
   50%{
-    background-color: #1a1a1aff;
+    background-color: #5d5d5daa;
   }
   100%{
     background-color: #1a1a1aa6;

--- a/web/src/components/PlayerCard/PlayerCardFb.jsx
+++ b/web/src/components/PlayerCard/PlayerCardFb.jsx
@@ -14,10 +14,15 @@ import CloseIcon from "@mui/icons-material/Close";
 import { IconButton } from "@mui/material";
 import StopProp from "@/components/StopProp/StopProp";
 import StreamerOutputBadge from "../StreamerOutputBadge/StreamerOutputBadge";
+import { getSourceZones } from "@/pages/Home/Home.jsx";
 
 import PropTypes from "prop-types";
 
 const PlayerCardFb = ({ sourceId, setVol }) => {
+    const zones = getSourceZones(
+        sourceId,
+        useStatusStore((s) => s.status.zones)
+    );
     const [streamModalOpen, setStreamModalOpen] = useState(false);
     const [zoneModalOpen, setZoneModalOpen] = useState(false);
     const setSelectedSource = usePersistentStore((s) => s.setSelectedSource);
@@ -78,7 +83,7 @@ const PlayerCardFb = ({ sourceId, setVol }) => {
                     <SongInfoMarquee sourceId={sourceId} />
                 </div>
 
-                { !is_streamer && (
+                { !is_streamer && zones.length > 0 && (
                     <CardVolumeSlider
                         sourceId={sourceId}
                         onChange={(event, vol) => {

--- a/web/src/components/ZonesBadge/ZonesBadge.jsx
+++ b/web/src/components/ZonesBadge/ZonesBadge.jsx
@@ -8,10 +8,10 @@ import Grid from "@mui/material/Grid/Grid";
 
 import PropTypes from "prop-types";
 
-const ZoneGroupChip = ({ zoneGroup, onClick, pulse}) => {
+const ZoneGroupChip = ({ zoneGroup, onClick, shake}) => {
     return (
         <Grid item xs={"auto"} sm={"auto"} md={"auto"} lg={"auto"} xl={"auto"}>
-            <Chip onClick={onClick} style={{maxWidth: "35vw"}} pulse={pulse} >
+            <Chip onClick={onClick} style={{maxWidth: "35vw"}} shake={shake} >
                 <div className="zone-text">{zoneGroup.name}</div>
             </Chip>
         </Grid>
@@ -20,7 +20,7 @@ const ZoneGroupChip = ({ zoneGroup, onClick, pulse}) => {
 ZoneGroupChip.propTypes = {
     zoneGroup: PropTypes.any.isRequired,
     onClick: PropTypes.func.isRequired,
-    pulse: PropTypes.bool,
+    shake: PropTypes.bool,
 };
 
 const ZonesBadge = ({ sourceId, onClick }) => {
@@ -87,7 +87,7 @@ const ZonesBadge = ({ sourceId, onClick }) => {
     } else {
         chips.push(
             <ZoneGroupChip
-                pulse
+                shake
                 key={0}
                 onClick={onClick}
                 zoneGroup={{ name: "Add Zones" }}

--- a/web/src/components/ZonesBadge/ZonesBadge.jsx
+++ b/web/src/components/ZonesBadge/ZonesBadge.jsx
@@ -8,10 +8,10 @@ import Grid from "@mui/material/Grid/Grid";
 
 import PropTypes from "prop-types";
 
-const ZoneGroupChip = ({ zoneGroup, onClick }) => {
+const ZoneGroupChip = ({ zoneGroup, onClick, pulse}) => {
     return (
         <Grid item xs={"auto"} sm={"auto"} md={"auto"} lg={"auto"} xl={"auto"}>
-            <Chip onClick={onClick} style={{maxWidth: "35vw"}}>
+            <Chip onClick={onClick} style={{maxWidth: "35vw"}} pulse={pulse} >
                 <div className="zone-text">{zoneGroup.name}</div>
             </Chip>
         </Grid>
@@ -20,6 +20,7 @@ const ZoneGroupChip = ({ zoneGroup, onClick }) => {
 ZoneGroupChip.propTypes = {
     zoneGroup: PropTypes.any.isRequired,
     onClick: PropTypes.func.isRequired,
+    pulse: PropTypes.bool,
 };
 
 const ZonesBadge = ({ sourceId, onClick }) => {
@@ -86,6 +87,7 @@ const ZonesBadge = ({ sourceId, onClick }) => {
     } else {
         chips.push(
             <ZoneGroupChip
+                pulse
                 key={0}
                 onClick={onClick}
                 zoneGroup={{ name: "Add Zones" }}

--- a/web/src/pages/Player/Player.jsx
+++ b/web/src/pages/Player/Player.jsx
@@ -88,7 +88,7 @@ const Player = () => {
                 <MediaControl selectedSource={selectedSourceId} />
             </div>
 
-            {!alone && !is_streamer && (
+            {!alone && !is_streamer && zones.length > 0 && (
                 <Card className="player-volume-slider">
                     <CardVolumeSlider sourceId={selectedSourceId} />
                     <IconButton onClick={() => setExpanded(!expanded)}>


### PR DESCRIPTION
### What does this change intend to accomplish?

Remove volume and mute controls when there is nothing playing on the player card and player page

Aims to close #637 by removing anything that suggests audio could be playing

What is specifically achieved is removing the volume bar and mute button from both the player card on the home page and the player page when a source has no zones, as well as making the "Add Zones" badge on the player card flash slowly when there aren't any zones attached

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] If this is a UI change, have you tested it across multiple browser platforms?
* [x] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
