### PR TITLE
Correct power output detail for the every channel used case

### DIFF
--- a/docs/manual/MAIN_CONTROLLER_SPECS.md
+++ b/docs/manual/MAIN_CONTROLLER_SPECS.md
@@ -23,6 +23,7 @@
 |||
 |Speaker Power     | 55 WPC @ 4 Ω |
 |                  | 32 WPC @ 8 Ω |
+|                  | 23 WPC all-channel driven power |
 |||
 |Speaker Impedance | 4 - 8 Ω |
 |||


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR attempts to add clarity around our all-channel peak output power (am I even saying that right?)

I'd like feedback on how this is represented; I will go through the process of stamping out a new rendered manual and hosting it upstream once the verbiage here is correct.

### Checklist

* [x] If applicable, have you updated the documentation/manual?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
