### PR TITLE
make only streams that aren't already playing selectable in StreamsModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Enforce breakpoint styling to ensure that the UI looks the same between mobile, desktop, tablet viewports
   * Groups containing disabled zones now behave as though those zones don't exist
   * Groups containing only disabled zones no longer selectable
+  * Only show not-playing streams in the new stream modal
 * Streams
   * Remove stop command (only accessable through API) from Pandora
   * Disconnect zones from sources when they are disabled

--- a/web/src/components/StreamsModal/StreamsModal.jsx
+++ b/web/src/components/StreamsModal/StreamsModal.jsx
@@ -31,6 +31,8 @@ const StreamsModal = ({
 }) => {
     const streams = useStatusStore((state) => state.status.streams);
     const status = useStatusStore((state) => state.status);
+    const playingStreams = status.sources.filter( (s) => s.input !== 'None').map( (s) => parseInt(s.input.replace('stream=', '')));
+    const availableStreams = streams.filter( (s) => !playingStreams.includes(s.id))
 
     const setStream = (stream) => {
         const streamId = stream.id;
@@ -79,7 +81,7 @@ const StreamsModal = ({
 
     let streamsList = [];
 
-    for (const stream of streams) {
+    for (const stream of availableStreams) {
         if (!stream.disabled) {
             const icon = getIcon(stream.type);
             streamsList.push(


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR makes modifies the StreamsModal, which is what launches when you attempt to start a new stream. It filters out all already-playing streams from the selection dialog. This is a bit of an inverted way to close #501 , but is possibly a bit more intuitive and helps avoid messy logic around keeping streams running on the same source with zero interruption and just adding zones to the source, which is what the ticket details. Instead, we shift left and make the user do this if this is their intention.

In the non-webapp context, one can still steal streams; that's explicitly supported functionality and lives within the `ctrl.py` code.

I'm pretty sure the `input` field is always either `'None'` or starts with `stream=`, but that's one way this is brittle, for sure.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms? Firefox & Chromium
* [x] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
