### PR TITLE
restart connected squeezelite clients every 2-3 days at 3:03AM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * Remove stop command (only accessable through API) from Pandora
   * Disconnect zones from sources when they are disabled
   * Updated Pianobar to fork of 2022.04.01
+  * Reset buggy LMS clients on a regular basis
 
 ## 0.3.6
 * Web App

--- a/config/crontab
+++ b/config/crontab
@@ -5,3 +5,7 @@
   0   5  *   *   *     sleep $(tr -cd 0-9 </dev/urandom | head -c 3)s; SCRIPTS_DIR/check-release
 #                      Check for internet access.
   */5 *  *   *   *     SCRIPTS_DIR/check-online
+# GitHub issue #702: LMS stream choppy and distorted after not being used for a few days
+# Reset any running LMS client streams on a consistent basis.
+# ref: https://github.com/micro-nova/AmpliPi/issues/702
+  3  3   *   *   */3   SCRIPTS_DIR/restart_lms_streams.sh

--- a/scripts/restart_lms_streams.sh
+++ b/scripts/restart_lms_streams.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# GitHub issue #702: LMS stream choppy and distorted after not being used for a few days
+# Reset any running LMS client streams on a consistent basis.
+# ref: https://github.com/micro-nova/AmpliPi/issues/702
+
+# All stream ids running LMS 
+LMS_STREAM_IDS=$(curl -s localhost/api | jq -r '.sources[] | select(.info.type == "lms") | .input' | sed s/stream=//)
+
+for id in ${LMS_STREAM_IDS}; do
+    curl -s -X POST localhost/api/streams/${id}/restart >/dev/null
+    sleep 3
+done
+


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR does something about #702 , though I hesistate to call it a fix. This is a simple cronjob that jams [our new `restart` command](https://github.com/micro-nova/AmpliPi/pull/734) every 2 to 3 days at 3:03AM.

I have not tested the cronjob, but I have tested the script. There's a brief pause where squeezelite is dead and comes back to life, but it respects prior volumes, streams that were running keep running, and streams that were stopped don't start - in other words, I don't expect this to start blaring music at 3AM for folks in the field. 

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
