### PR TITLE
Restart LMS clients every day

### DIFF
--- a/config/crontab
+++ b/config/crontab
@@ -8,4 +8,4 @@
 # GitHub issue #702: LMS stream choppy and distorted after not being used for a few days
 # Reset any running LMS client streams on a consistent basis.
 # ref: https://github.com/micro-nova/AmpliPi/issues/702
-  3  3   *   *   */3   SCRIPTS_DIR/restart_lms_streams.sh
+  3  3   *   *   *     SCRIPTS_DIR/restart_lms_streams.sh


### PR DESCRIPTION
### What does this change intend to accomplish?
A fast follow to #779 , restart squeezelite clients more frequently. Continues to fix #702 . This is a request from a customer who uses LMS heavily.

### Checklist
None apply; the CHANGELOG language stays valid from #779.
