### PR TITLE
Fix Spotify _deactivate() wrt mpris

### DIFF
--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -660,12 +660,11 @@ class Spotify(PersistentStream):
     if self.proc:
       utils.careful_proc_shutdown(self.proc, "spotify stream")
       self.proc = None
-    if self.mpris:
-      try:
-        del self.mpris
-      except Exception:
-        pass
-      self.mpris = None
+    try:
+      del self.mpris
+    except Exception:
+      pass
+    self.mpris = None
     self.connect_port = None
 
   def info(self) -> models.SourceInfo:


### PR DESCRIPTION
### What does this change intend to accomplish?
This fixes a bug that cropped up during spec creation. I don't know a lot about the interactions with our mpris metadata stuff ehre, but logically this feels correct? Gonna draft PR this as I test it on an actual AmpliPi, but the spec creation completes without traceback now.

The former traceback:
```
$ ./scripts/create_spec 
Exception ignored in: <function PersistentStream.__del__ at 0x7f20cd2f9b20>
Traceback (most recent call last):
  File "/home/l4zmq2r/work/repos/AmpliPi/amplipi/streams.py", line 254, in __del__
    self.deactivate()
  File "/home/l4zmq2r/work/repos/AmpliPi/amplipi/streams.py", line 294, in deactivate
    raise Exception(f'Failed to deactivate {self.name}: {e}') from e
Exception: Failed to deactivate Jasons House: 'Spotify' object has no attribute 'mpris'
```

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
