### PR TITLE
Correct loglevel in lms_metadata to reduce logging noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Web App
   * Migrate more inputs to MUI
   * Fix internet radio searching during stream creation
+* System
+  * Reduce noisy logging from lms_metadata.py
 
 ## 0.4.0
 * System

--- a/streams/lms_metadata.py
+++ b/streams/lms_metadata.py
@@ -62,15 +62,14 @@ class LMSMetadataReader:
     self.debug = os.environ.get('DEBUG', False)
 
     self.logger = logging.getLogger(__name__)
+    log_level = logging.INFO
     if self.debug:
-      self.logger.setLevel(logging.DEBUG)
-    else:
-      self.logger.setLevel(logging.INFO)
+      log_level = logging.DEBUG
     sh = logging.StreamHandler(sys.stdout)
     self.logger.addHandler(sh)
 
-    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-    self.logger.setLevel(logging.DEBUG)
+    logging.basicConfig(stream=sys.stdout, level=log_level)
+    self.logger.setLevel(log_level)
     self.meta = MetadataHolder(artist='Loading...',
                                album='Loading...',
                                track='Loading...',


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR corrects our log level handling in `lms_metadata.py`. Prior, it would always reset logging to `logging.DEBUG`, which is problematic for the underlying `urllib` which has its own `sys.stdout` stream handlers. This change was prompted by multiple bugs and troubleshooting scenarios not having enough logging because of the noisy journal being rotated often.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
