### PR TITLE
always download config when toggling LMS mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Web App
   * Migrate more inputs to MUI
   * Fix internet radio searching during stream creation
+  * Download appliance config when toggling LMS mode off
 * System
   * Reduce noisy logging from lms_metadata.py
   * Fix install of FM radio software `redsea`

--- a/web/src/pages/Settings/Config/ConfigPanels/LMSMode.jsx
+++ b/web/src/pages/Settings/Config/ConfigPanels/LMSMode.jsx
@@ -25,7 +25,7 @@ export default function LMSMode() {
             return(
                 <ConfigModal
                     body={"This will reset AmpliPi to factory settings, you will have to either manually reconfigure it or reupload the config that was downloaded when LMS mode was initially toggled."}
-                    onApply={() => {LMSModeHandler();}}
+                    onApply={() => {ConfigDownload(); LMSModeHandler();}}
                     open={modalOpen}
                     setOpen={setModalOpen}
                 />
@@ -59,7 +59,7 @@ export default function LMSMode() {
 
             <LMSModal />
             <StatusBar
-                successText={"LMS Mode activated successfully!"}
+                successText={"LMS Mode toggled successfully!"}
                 response={response}
             />
         </>


### PR DESCRIPTION
### What does this change intend to accomplish?
Always download the config when toggling LMS mode. I forgot I had enabled LMS mode and configured my appliance with other sources. Toggling it off meant I wiped out my config, with no backup. This fixes that. It also has a minor terminology fix - toggling LMS mode off previously stated it was enabled successfully in the toast; now it says it was toggled successfully.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
