### PR TITLE
fix redsea install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Fix internet radio searching during stream creation
 * System
   * Reduce noisy logging from lms_metadata.py
+  * Fix install of FM radio software `redsea`
 
 ## 0.4.0
 * System

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -176,15 +176,17 @@ _os_deps: Dict[str, Dict[str, Any]] = {
         'apt': ['vlc']
     },
     'fmradio': {
-        'apt': ['rtl-sdr', 'git', 'build-essential', 'autoconf', 'libsndfile1-dev', 'libliquid-dev'],
+        'apt': ['rtl-sdr', 'git', 'build-essential', 'libsndfile1-dev', 'libliquid-dev', 'meson'],
         'script': [
             'if ! which redsea  > /dev/null; then',  # TODO: check version
             '  echo "Installing redsea"',
             '  cd /tmp',
             '  git clone --depth 1 https://github.com/windytan/redsea.git',
             '  cd redsea',
-            '  ./autogen.sh && ./configure && make',
-            '  sudo make install',
+            '  meson setup build',
+            '  cd build',
+            '  meson compile',
+            '  sudo cp redsea /usr/local/bin/',
             '  sudo wget https://raw.githubusercontent.com/osmocom/rtl-sdr/master/rtl-sdr.rules -P /etc/udev/rules.d/',
             '  sudo udevadm control --reload-rules',
             '  sudo udevadm trigger',


### PR DESCRIPTION
### What does this change intend to accomplish?
[`redsea` moved to `meson` for builds last month](https://github.com/windytan/redsea/issues/90). This PR fixes our install of `redsea` from source.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`