### PR TITLE
ReturnBlueTheme

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -80,7 +80,12 @@ export const router = createHashRouter([
 
 const darkTheme = createTheme({
     palette: {
-        primary: grey,
+        primary: {
+            main: '#90caf9', // MUI default blue
+            light: '#e3f2fd',
+            dark: '#42a5f5',
+            contrastText: '#fff',
+          },
         mode: "dark",
         background: {
             paper: "#2a2a2a", // TODO: no good way of getting this from scss...


### PR DESCRIPTION
### What does this change intend to accomplish?
Re-add the default blue theming from MUI
#800 changed the theming of the webapp to have grey as the primary interactable color, I disliked it and dug through the mui docs to find the default settings:
https://mui.com/material-ui/customization/theming/
https://mui.com/material-ui/customization/palette/

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] If this is a UI change, have you tested it across multiple browser platforms?
* [x] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
