### PR TITLE
check-release on reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * System
   * Reduce noisy logging from lms_metadata.py
   * Fix install of FM radio software `redsea`
+  * Fix latest version checking after an update
 * Streams
   * File Players can be temporary. A temporary File Player will remove itself from the list of available streams once disconnected from all sources.
   * File Players run their own Python container process similar to Internet Radio Stations, rather than running a cvlc command.

--- a/config/crontab
+++ b/config/crontab
@@ -3,6 +3,7 @@
 # m   h  dom mon dow   command
 #                      Check for new release, add jitter to avoid overloading GitHub.
   0   5  *   *   *     sleep $(tr -cd 0-9 </dev/urandom | head -c 3)s; SCRIPTS_DIR/check-release
+  @reboot              SCRIPTS_DIR/check-release
 #                      Check for internet access.
   */5 *  *   *   *     SCRIPTS_DIR/check-online
 # GitHub issue #702: LMS stream choppy and distorted after not being used for a few days

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ include = [
   "config/boot_config.txt",
   "config/support_tunnel_crontab",
   "config/support_group_sudoers",
+  "config/crontab",
   "debs/**/*",
   "fw/*.sh", # no need to add full source tree
   "fw/bin/*",


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR runs `check-release` on reboot, which accomplishes running post-upgrade too. Funnily enough, the crontab wasn't being packaged up by pyproject; this fixes this as well.

This tackles one half of #798 ; it may prevent all of it, but it's hard to tell when running on a non-release branch at the moment. I'll track that bug separately.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`