### PR TITLE
Fix display service on authenticated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
   * Reduce noisy logging from lms_metadata.py
   * Fix install of FM radio software `redsea`
   * Fix latest version checking after an update
-  * Fixed updates on systems with an API password set
   * Move system state out of running software directory
+  * Fix updates on systems with an API password set
+  * Fix the display service on systems with an API password set
 * Streams
   * File Players can be temporary. A temporary File Player will remove itself from the list of available streams once disconnected from all sources.
   * File Players run their own Python container process similar to Internet Radio Stations, rather than running a cvlc command.

--- a/amplipi/auth.py
+++ b/amplipi/auth.py
@@ -5,7 +5,7 @@ import secrets
 import logging
 import sys
 
-from typing import Union, Dict
+from typing import Union, Dict, List
 from typing_extensions import Literal
 from datetime import datetime, timedelta, timezone
 
@@ -240,6 +240,11 @@ def no_user_passwords_set() -> bool:
     if _user_password_set(user):
       return False
   return True
+
+
+def list_users() -> List[str]:
+  """ Returns a flat list of username strings. """
+  return list(_get_users())
 
 
 def _next_url(request: Request) -> str:

--- a/amplipi/display/tftdisplay.py
+++ b/amplipi/display/tftdisplay.py
@@ -20,7 +20,7 @@ from loguru import logger as log
 
 from amplipi import models
 from amplipi.utils import get_identity
-from amplipi.display.common import Color, Display, DefaultPass, get_status
+from amplipi.display.common import Color, Display, DefaultPass, get_status, request_params
 from amplipi.display.statusinterface import DisplayError, DisplayStatus, set_custom_display_status
 
 # If this is run on anything other than a Raspberry Pi,
@@ -590,7 +590,7 @@ def get_amplipi_data(base_url: Optional[str]) -> Tuple[bool, List[models.Source]
   try:
     """ TODO: If the AmpliPi server isn't available at this url, there is a
     5-second delay introduced by socket.getaddrinfo """
-    req = requests.get(base_url, timeout=0.2)
+    req = requests.get(base_url, timeout=0.2, params=request_params())
     if req.status_code == 200:
       status = models.Status(**req.json())
       _zones = status.zones


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR fixes the display service on authenticated APIs, fetching the first user's session key directly from storage and using it in requests to the API. This methodology will have to change when we graduate beyond using a single user, but so will many other things around authentication as well. 

This has been tested against both e-ink and tft displays. I added a function to a shared module, so I've revisited the tests as well and souped them up.


### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] Have you written new tests for your core features/changes, as applicable?

