### PR TITLE
SilenceAutoselection

### DIFF
--- a/web/src/utils/selectActiveSource.jsx
+++ b/web/src/utils/selectActiveSource.jsx
@@ -13,7 +13,11 @@ export default function selectActiveSource(){ // Selects an active source, if th
     let run = false;
 
     // If selected source is not active, select the source with the lowest ID
-    if(!sources || !sources[selectedSource] || !sources[selectedSource]["input"]){
+    if(
+        (!sources[selectedSource] || !sources[selectedSource]["input"])
+        &&
+        sources.some(source => (source["input"] !== "None") && (source['input'] !== "")) // similar to a python "if value in array['header']"
+    ){
         // While testing this script along with the one that autoselects the created source when adding a new source,
         // I found that there were times that a source could reach an undefined variable
 


### PR DESCRIPTION
### What does this change intend to accomplish?
Closes #829, reduces methods of `run=True` (and therefore the number of paths that print `"Source data missing, selecting a new source"` into the console) in `selectActiveSource.jsx`

Not updating changelog as this is a minor fix, and fixes something that isn't in an update yet

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
