### PR TITLE
Some tweaks to bluetooth for robustness

### DIFF
--- a/streams/bluetooth.py
+++ b/streams/bluetooth.py
@@ -131,7 +131,8 @@ def get_all_devices_path_and_mac() -> List[tuple]:
 def mac_to_device_name(mac: str) -> Optional[str]:
   try:
     devices = subprocess.run('bluetoothctl devices'.split(), timeout=0.5, check=True, capture_output=True).stdout.decode()
-  except Exception:
+  except Exception as e:
+    print(f"unable to query bluetooth devices in mac_to_device_name(): {e}")
     devices = ''
   for line in devices.splitlines():
     if line.split()[1].lower() == mac.lower():
@@ -210,9 +211,10 @@ def main():
           baplay_args = f'bluealsa-aplay -d {args.output_device} {selected_device} --single-audio'
           bluealsa_proc = subprocess.Popen(args=baplay_args.split(), preexec_fn=os.setpgrp)
         # write the new mac address to the device info file, used by streams.py bluetooth send command
-        with open(args.device_info, "wt") as f:
-          f.write(selected_device)
-          print(f'Writing {selected_device} to {args.device_info}')
+        if selected_device is not None:
+          with open(args.device_info, "wt") as f:
+            f.write(selected_device)
+            print(f'Writing {selected_device} to {args.device_info}')
 
       if selected_device:
         try:


### PR DESCRIPTION
### What does this change intend to accomplish?
It appears #836 is actually because of some strange firmware business with the single USB transceiver we've been passing around at work - my crappy transceiver from home worked (almost) out of the box. There are two tweaks I made to this though, for the first-run case I saw with my dongle from home - I suspect `bluetoothctl` timed out once in `mac_to_device_name`, but have no data to confirm that. This adds better logging and handling around that case.

I'm not sure this justifies a CHANGELOG entry. what do you think?

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [ ] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
