### PR TITLE
Revert b728da867 to prevent frequent re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Streams
   * Internet radio can now play playlists from the `pls`, `m3u8`, and `m3u` formats.
   * Fixed bug where internet radio process would not completely stop when the stream was stopped.
+* Web App
+  * Fix a bug that caused re-renders on settings modals
 
 ## 0.4.1
 * Web App

--- a/web/src/pages/Settings/Settings.jsx
+++ b/web/src/pages/Settings/Settings.jsx
@@ -23,7 +23,6 @@ import ListItem from "@/components/List/ListItem/ListItem";
 import List from "@/components/List/List";
 import { IsMobileApp, IsSaved, SaveURL, UnsaveURL } from "@/utils/MobileApp";
 import Badge from "@mui/material/Badge";
-import selectActiveSource from "@/utils/selectActiveSource";
 
 import PropTypes from "prop-types";
 import Checkbox from "@mui/material/Checkbox";
@@ -89,10 +88,6 @@ Page.propTypes = {
 const Settings = ({ openPage }) => {
     const is_streamer = useStatusStore((s) => s.status.info.is_streamer);
     const [isSavedUrl, setIsSavedUrl] = React.useState(IsSaved());
-
-    // Make sure player tab doesn't just disappear when navigating to the settings page
-    // This can only happen due to another user closing the previously selected stream
-    selectActiveSource();
 
     if (openPage != "") {
         return <Page openPage={openPage} />;

--- a/web/src/utils/selectActiveSource.jsx
+++ b/web/src/utils/selectActiveSource.jsx
@@ -1,8 +1,9 @@
 import { useStatusStore, usePersistentStore } from "@/App";
 
 // Import and use this function on every main page
-// Currently, that means the Home, Player, and Settings pages
+// Currently, that means the Home and Player pages
 // Not the Browse page, as not all selectable streams can be browsed and that feels likely to seem like an error to a user
+// Not the settings page, due to rerendering issues described in GH issue #839.
 export default function selectActiveSource(){ // Selects an active source, if the selected source is inactive
     const sources = useStatusStore((s) => s.status.sources);
     const selectedSource = usePersistentStore((s) => s.selectedSource);


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR reverts b728da867 to fix #839 . Introducing `selectActiveSource` has made the Settings page stateful; this means it triggers a re-render every 1s, when we poll the upstream API for current state. I've tried removing all the state from the LMS Mode bits, but that's not what's causing the re-render anyways and did nothing.

A couple bigger/longer term fixes could include:
* rearchitecting the API to send only changes over websocket; this would rerender only on those changes, and depending on how decomposed those channels are we could easily prevent rerendering on changes by only updating, say, player objects instead of everything.
* creating an API endpoint to simply query lms_mode directly upon config page load. That feels like a hack, but would definitely work in the 99th percentile case.

I'm pretty sure there's a way to spend some time and make this work as intended, but this went deeper than expected and I'm not convinced the juice is worth the squeeze. Can you describe what case the introduction of `selectActiveSource` actually handles? If it's just two people using the same AmpliPi at once and someone deletes a player/source, that feels like a case not worth adding this additional complexity (given its side effects), tho it's likely I'm just not understanding the root cause here.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`