### PR TITLE
Let runvlc try to initially open a stream forever; retry streams forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Streams
   * Internet radio can now play playlists from the `pls`, `m3u8`, and `m3u` formats.
   * Fixed bug where internet radio process would not completely stop when the stream was stopped.
+  * Fixed bug where internet radio process would permenantly fail during transient network errors
 * Web App
   * Fix a bug that caused re-renders on settings modals
 


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR fixes #832 by permitting runvlc to loop forever when a stream first starts. Our prior logic bailed quickly; this instead calls a wrapped `restart_vlc()` when it fails and lets `restart_vlc` implement a backoff for persistently failed streams.

This PR also creates a new RestartVlcException and handles the restarting case "better" when a stream breaks when already started; we again attempt to restart forever. I'm running this on a started-but-disconnected amplipi overnight and seeing if it works when I plug it back in in the morning.

The initial bug occurred in our testing setup when the internet connection was shaky on first boot; I can imagine user cases where these are very helpful fixes, like with less-than-stable internet on a boat ;)

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
