### PR TITLE
Fix internet radio logo field validation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Internet radio can now play playlists from the `pls`, `m3u8`, and `m3u` formats.
   * Fixed bug where internet radio process would not completely stop when the stream was stopped.
   * Fixed bug where internet radio process would permenantly fail during transient network errors
+  * Fixed a bug where a missing logo prevents saving & showing streams
 * Web App
   * Fix a bug that caused re-renders on settings modals
 

--- a/amplipi/streams.py
+++ b/amplipi/streams.py
@@ -23,7 +23,6 @@ a consistent interface.
 
 import os
 import traceback
-from re import sub
 import sys
 import subprocess
 import time
@@ -31,7 +30,6 @@ from typing import Union, Optional, List, ClassVar
 import threading
 import re
 import logging
-import ast
 import json
 import signal
 import socket
@@ -1171,7 +1169,7 @@ class InternetRadio(BaseStream):
     # parse each playlist type and get the urls from them
     PLAYLIST_TYPES = ['pls', 'm3u', 'm3u8']
     if self.url.split('.')[-1] in PLAYLIST_TYPES:
-      logger.info(f'Playlist detected, attempting to get playlist...')
+      logger.info('Playlist detected, attempting to get playlist...')
       try:
         req = requests.get(self.url)
         urls = re.compile(r'(http.*?)[\r\n]').findall(req.text)
@@ -1252,7 +1250,8 @@ class InternetRadio(BaseStream):
     URL_LIKE = r'^https?://[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$'
     if 'url' in kwargs and not re.fullmatch(URL_LIKE, kwargs['url']):
       raise InvalidStreamField("url", "invalid url")
-    if 'logo' in kwargs and not re.fullmatch(URL_LIKE, kwargs['logo']):
+    # Logo is Optional[str]
+    if 'logo' in kwargs and kwargs['logo'] and not re.fullmatch(URL_LIKE, kwargs['logo']):
       raise InvalidStreamField("logo", "invalid logo url")
 
 
@@ -1687,7 +1686,7 @@ class LMS(PersistentStream):
       try:
         self.meta_proc.terminate()
         self.meta_proc.communicate(timeout=10)
-      except:
+      except Exception as e:
         logger.exception(f"failed to gracefully terminate LMS meta proc for {self.name}: {e}")
         logger.warning(f"forcefully killing LMS meta proc for {self.name}")
         os.killpg(self.meta_proc.pid, signal.SIGKILL)


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR fixes #848 . The `logo` field is marked as `Optional[str]` in the function that calls `validate_sttream`, and a `None` gets passed in when we do not specify one. This broke the regex processing; I've gated that with a truthy test first.

I also took the opportunity to revisit a couple of stream's `validate_stream()` methods to explicitly ensure required values are set. We don't bump into this because our frontend also does field validation for required fields, but helps the API/automation case. This has the potential side effect of breaking existing streams in the world that don't implement required fields, but I think they'd just be broken anyhow.

I check my code with `ruff`, and it spotted a couple of actual errors too and errata; I've fixed those here as well.

I've tested every stream I modified through the frontend, and all still instantiate & function as expected.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`