### PR TITLE
Take regular backups of the config to ~pi/backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * Delete generated tarball after finishing deploying using scripts/deploy
 * System
   * Fixed bug where the logs would be filled with errors when startign Spotify.
+  * Take regular configuration backups to the backend
 
 ## 0.4.1
 * Web App

--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+ag amplipi-dev
+ag home

--- a/config/crontab
+++ b/config/crontab
@@ -6,6 +6,7 @@
   @reboot              SCRIPTS_DIR/check-release
 #                      Check for internet access.
   */5 *  *   *   *     SCRIPTS_DIR/check-online
+  0   2  *   *   *     SCRIPTS_DIR/backup_config.sh
 # GitHub issue #702: LMS stream choppy and distorted after not being used for a few days
 # Reset any running LMS client streams on a consistent basis.
 # ref: https://github.com/micro-nova/AmpliPi/issues/702

--- a/docs/manual/TROUBLESHOOTING.md
+++ b/docs/manual/TROUBLESHOOTING.md
@@ -33,8 +33,22 @@ Had an issue with an update? Want to try a beta release? Follow these steps:
 4. Select the release you would like to use from the dropdown menu
 5. Click the **Start Update** button
 
+## Taking and restoring configuration backups
+
+There are two ways configuration backups are made - manually through the frontend, and nightly within the backend via a scheduled job.
+
+### Manual backups and restores
+
+Manual backups are taken by navigating to ⚙ -> Config -> Download Config. This configuration includes all configured streams. These backups can be restored using ⚙ -> Config -> Upload Config. It is a good idea to take a manual backup before upgrading your appliance.
+
+### Automated system backups and restores
+
+Automated backups are also taken nightly at 2AM and stored for 30 days. These are raw system backups, accessible only by an advanced user via the backend. These backups help either support, or a technical user, to restore prior system configuration from a particular point in time. If the below instructions do not make sense to you, you should feel free to email [support@micro-nova.com](mailto:support@micro-nova.com) and we can help restore a backup from your appliance.
+
+These backups are dated tarballs stored at `~pi/backups`. This tarball contains the entire `~pi/.config/amplipi` directory. To restore this backup, stop the AmpliPi service (`systemctl stop --user amplipi` as the `pi` user), unpack the tarball, overwrite the `~pi/.config/amplipi` directory with the contents of the backup, and start AmpliPi again (`systemctl start --user amplipi`).`
+
 ## Reimaging AmpliPro
-For directions on how to bring AmpliPro system back to a previous version, scan the QR labeled "Reimaging Instructions" on the links page at the start of this manual.
+For directions on how to bring AmpliPro system back to a previous version, scan the QR labeled "Reimaging Instructions" on the links page at the start of this manual, or [click this link](https://github.com/micro-nova/AmpliPi/blob/main/docs/imaging_etcher.md). It is a good idea to take a system backup before running this process; see the above section labelled "Taking and restoring configuration backups".
 
 ## Still need help?
 

--- a/scripts/backup_config.sh
+++ b/scripts/backup_config.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+date="$(date --iso-8601='seconds')"
+backup_dir="${HOME}/backups"
+backup_filename="${backup_dir}/config_backup-${date}.tgz"
+
+echo "taking a config backup..."
+mkdir -p "${backup_dir}"
+tar --one-file-system -czf "${backup_filename}" "${HOME}/.config/amplipi/"
+
+# remove all backups older than 30 days
+echo "removing old backups..."
+find "${backup_dir}" -type f -ctime +30 -delete


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR is a simple, barebones point-in-time backup of a user's `.config` directory. We appear to write back the config at most every 5s during changes, through the `save_on_success` wrapper in `ctrl.py`, so simply creating tarballs like this feels acceptable. We could implement a frontend to allow users to restore prior configs more-automated-ly, but that is a bigger task and I'm unconvinced I want to do that now, when a simple support case or user-initiated SSH session can fix this; as an interim solution, I've documented in our docs how to backup and restore both manual and cronjob-generated backups.

I've opted to stash these in ~pi/backups because /home is where we intend to store state that moves across versions of OS we deploy post- #599 . A test backup on my appliance consumed ~1.5kb.

I've tested the script and it works; I'm going to wait overnight to make sure the cronjob kicks off on my appliance as well.

### Checklist

* [ ] Have you tested your changes and ensured they work? - just waiting on cronjob
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
