### PR TITLE
Delete tarball when deploy script finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * Fix a bug that caused re-renders on settings modals
 * Display
   * Status now displays number of playing, paused, stopped, and muted zones.
+* Developing
+  * Delete generated tarball after finishing deploying using scripts/deploy
 * System
   * Fixed bug where the logs would be filled with errors when startign Spotify.
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -195,6 +195,8 @@ $fw && opts="$opts --firmware"
 $pw && opts="$opts --password"
 $deps && opts="$opts --os-deps --python-deps"
 ssh $user_host -t "python3 amplipi-dev/scripts/configure.py --web --restart-updater --display --audiodetector$opts" || echo ""
+echo "Deleting tarball at ${release_name}.tar.gz"
+ssh $user_host "rm ${release_name}.tar.gz"
 
 printf "Waiting for AmpliPi to restart"
 restart_finished=false


### PR DESCRIPTION
This change removes the tarball generated by `scripts/deploy` after the script finishes.

### Checklist

* [X] Have you tested your changes and ensured they work?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] If applicable, have you updated the CHANGELOG?
* [X] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
