### PR TITLE
prevent avahi from serving support_tunnel addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Fix internet radio search on IOS app
   * Update styling on Settings pages, ensure they fit all mobile screens properly
   * Change "<- Back to App" button on the updater page to redirect to the settings page rather than the homepage
+* System
+  * Fixed a bug where support tunnel addresses would be served when querying for amplipi.local
 
 ## 0.4.2
 * Streams

--- a/config/support_tunnel_config.ini
+++ b/config/support_tunnel_config.ini
@@ -1,0 +1,3 @@
+[device]
+post-up-script=/usr/local/bin/support_tunnel_post_up.sh {iface}
+post-down-script=/usr/local/bin/support_tunnel_post_down.sh {iface}

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -131,6 +131,21 @@ _os_deps: Dict[str, Dict[str, Any]] = {
                 'from': 'config/support_group_sudoers',
                 'to': '/etc/sudoers.d/099_support-nopasswd',
                 'sudo': 'true'
+            },
+            {   # support tunnel scripts must be only be writable by root
+                'from': 'scripts/support_tunnel_post_up.sh',
+                'to': '/usr/local/bin/support_tunnel_post_up.sh',
+                'sudo': 'true'
+            },
+            {
+                'from': 'scripts/support_tunnel_post_down.sh',
+                'to': '/usr/local/bin/support_tunnel_post_down.sh',
+                'sudo': 'true'
+            },
+            {
+                'from': 'config/support_tunnel_config.ini',
+                'to': '/etc/support_tunnel/config.ini',
+                'sudo': 'true'
             }
         ],
         'script': [
@@ -441,6 +456,9 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
     if _to[0] != '/':
       _to = f"{env['base_dir']}/{_to}"
     _sudo = "sudo " if 'sudo' in file else ""
+    _parent_dir = pathlib.Path(_to).parent
+    if not _parent_dir.exists():
+      tasks += print_progress([Task(f"creating parent dir(s) for {_from}", f"{_sudo}mkdir -p {_parent_dir}".split()).run()])
     tasks += print_progress([Task(f"copy -f {_from} to {_to}", f"{_sudo}cp -f {_from} {_to}".split()).run()])  # shairport needs the -f if it is running
   if env['is_amplipi'] or env['is_ci']:
     # copy alsa configuration file

--- a/scripts/support_tunnel_post_down.sh
+++ b/scripts/support_tunnel_post_down.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This script runs after a support tunnel comes down. Right now, 
+# it only prevents Avahi from advertising using the wireguard interface
+# $1 is the wireguard interface to remove
+
+# The avahi-daemon.conf follows an ini-style convention; Python's
+# configparser makes it easy to safely add & remove contents in a particular
+# section, and "shelling out" gives us an opportunity to use `sudo`.
+echo "import configparser
+import sys
+config = configparser.ConfigParser()
+config.read('/etc/avahi/avahi-daemon.conf')
+if not config.has_section('server'):
+  config.add_section('server')
+deny = set(config['server'].get('deny-interfaces').split(','))
+try:
+  deny.remove('${1}')
+except KeyError as e:
+  print(f'${1} not in config; exiting early.')
+  sys.exit(1)
+deny_str = ''
+for i, d in enumerate(deny):
+  deny_str += f'{d}'
+  deny_str += ',' if i != (len(deny) - 1) else ''
+config['server']['deny-interfaces'] = deny_str
+with open('/etc/avahi/avahi-daemon.conf', 'w') as f:
+  config.write(f, space_around_delimiters=False)
+" | sudo python3 -
+
+sudo systemctl restart avahi-daemon

--- a/scripts/support_tunnel_post_up.sh
+++ b/scripts/support_tunnel_post_up.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This script runs after a support tunnel comes up. Right now, 
+# it only prevents Avahi from advertising using the wireguard interface
+# $1 is the wireguard interface name
+
+# The avahi-daemon.conf follows an ini-style convention; Python's
+# configparser makes it easy to add & remove contents in a particular
+# section, and "shelling out" gives us an opportunity to use `sudo`
+echo "import configparser
+config = configparser.ConfigParser()
+config.read('/etc/avahi/avahi-daemon.conf')
+if not config.has_section('server'):
+  config.add_section('server')
+deny = config['server'].get('deny-interfaces', '').split(',')
+deny = [d for d in deny if d] # removes falsy ''
+deny.append('${1}')
+deny = set(deny) # remove duplicates
+deny_str = ''
+for i, d in enumerate(deny):
+  deny_str += f'{d}'
+  deny_str += ',' if i != (len(deny) - 1) else ''
+config['server']['deny-interfaces'] = deny_str
+with open('/etc/avahi/avahi-daemon.conf', 'w') as f:
+  config.write(f, space_around_delimiters=False)
+" | sudo python3 -
+sudo systemctl restart avahi-daemon


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR stops avahi from serving addresses that are used with the support_tunnel. It does this by adding and removing entries from `avahi-daemon.conf`'s `deny-interfaces`. I would have liked to accomplish this another way - it's more than a little messy to modify and reload service configs on the fly like this - but avahi does not support any `conf.d`-style includes.

I've tested this a bunch. If you also wanted to test this, be sure to run a `support_tunnel` on your AmpliPi with https://github.com/micro-nova/support_tunnel/pull/26 merged. 

It also adds a little helper in `configure.py` for files being copied that do not yet have a parent directory.

This fixes #826 

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [ ] Have you written new tests for your core features/changes, as applicable?