### PR TITLE
About Page new tab links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Fix internet radio search on IOS app
   * Update styling on Settings pages, ensure they fit all mobile screens properly
   * Change "<- Back to App" button on the updater page to redirect to the settings page rather than the homepage
+  * Update links on "About" settings tab to open in a new tab
 * System
   * Fixed a bug where support tunnel addresses would be served when querying for amplipi.local
 

--- a/web/src/pages/Settings/About/About.jsx
+++ b/web/src/pages/Settings/About/About.jsx
@@ -16,17 +16,23 @@ const About = ({ onClose }) => {
         }
         return temp_string
     }
-    
+
     return (
         <>
             <PageHeader title="About" onClose={onClose} />
             <div className="about-body">
-                <a className="link" href="http://www.amplipi.com">
-          Amplipi ™
+                <a
+                    target="_blank"
+                    className="link"
+                    href="http://www.amplipi.com">
+          AmpliPro ™
                 </a>
                 <br />
         by{" "}
-                <a className="link" href="http://www.micro-nova.com">
+                <a
+                    target="_blank"
+                    className="link"
+                    href="http://www.micro-nova.com">
           MicroNova
                 </a>{" "}
         © {new Date(Date.now()).getFullYear()}
@@ -34,13 +40,13 @@ const About = ({ onClose }) => {
         Version: {info.version}
                 <br />
         {!info.is_streamer && ( <>
-        Main Unit Firmware Version: {info.fw.length ? info.fw[0].version: "No Preamp"} 
+        Main Unit Firmware Version: {info.fw.length ? info.fw[0].version: "No Preamp"}
                 <br />
         </> ) }
         {info.fw.length > 1 && ( <>
         Expansion Unit Firmware Version{info.fw.length > 2? "s": ""}: {generateBoardVersionsString(info.fw)}
                 <br />
-        </> ) }               
+        </> ) }
         Latest: {info.latest_release}
                 <br />
         {info.access_key && ( <>
@@ -49,27 +55,35 @@ const About = ({ onClose }) => {
         </> ) }
                 <div className="about-links">
           Links:
-                    <a className="link" href="/doc">
+                    <a
+                        target="_blank"
+                        className="link"
+                        href="/doc">
             Browsable API
                     </a>
-                    <a className="link" href="https://github.com/micro-nova/AmpliPi">
+                    <a
+                        target="_blank"
+                        className="link"
+                        href="https://github.com/micro-nova/AmpliPi">
             Github
                     </a>
-                    <a className="link" href="https://amplipi.discourse.group/">
+                    <a
+                        target="_blank"
+                        className="link"
+                        href="https://amplipi.discourse.group/">
             Community
                     </a>
                     <a
+                        target="_blank"
                         className="link"
                         href="https://github.com/micro-nova/AmpliPi/blob/main/COPYING"
                     >
             License
                     </a>
                     <a
-                        href={window.location.href}
-                        onClick={() => {
-                            window.location.href =
-                "http://" + window.location.hostname + ":19531/entries";
-                        }}
+                        target="_blank"
+                        className="link"
+                        href={`http://${window.location.hostname}:19531/entries`}
                     >
             Logs
                     </a>


### PR DESCRIPTION
### What does this change intend to accomplish?
Add 'target="_blank" to all links on the About page to make all links open in a new tab
Add proper classname to 'logs' link so it stops being that near-invisible purple

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] If applicable, have you updated the documentation/manual?
* [ ] If applicable, have you updated the CHANGELOG?
* [ ] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] Have you written new tests for your core features/changes, as applicable?
* [x] If this is a UI change, have you tested it across multiple browser platforms?
* [x] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
