### PR TITLE
Make internet radio URL validation more correct & robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Update links on "About" settings tab to open in a new tab
 * System
   * Fixed a bug where support tunnel addresses would be served when querying for amplipi.local
+  * Stream validation for URLs has been made more robust
 
 ## 0.4.2
 * Streams

--- a/amplipi/streams/internet_radio.py
+++ b/amplipi/streams/internet_radio.py
@@ -1,5 +1,6 @@
 from .base_streams import BaseStream, InvalidStreamField, logger
 from typing import ClassVar, Optional
+from urllib.parse import urlparse
 from amplipi import models, utils
 import subprocess
 import time
@@ -8,6 +9,7 @@ import re
 import requests
 import json
 import sys
+import validators
 
 
 class InternetRadio(BaseStream):
@@ -137,9 +139,15 @@ class InternetRadio(BaseStream):
       pass
 
   def validate_stream(self, **kwargs):
-    URL_LIKE = r'^https?://[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$'
-    if 'url' in kwargs and not re.fullmatch(URL_LIKE, kwargs['url']):
-      raise InvalidStreamField("url", "invalid url")
+    if 'url' in kwargs and kwargs['url']:
+      if not validators.url(kwargs['url']):
+        raise InvalidStreamField("url", "invalid url")
+      if urlparse(kwargs['url']).scheme not in ['http', 'https']:
+        raise InvalidStreamField("url", "unsupported protocol/scheme in url")
+
     # Logo is Optional[str]
-    if 'logo' in kwargs and kwargs['logo'] and not re.fullmatch(URL_LIKE, kwargs['logo']):
-      raise InvalidStreamField("logo", "invalid logo url")
+    if 'logo' in kwargs and kwargs['logo']:
+      if not validators.url(kwargs['logo']):
+        raise InvalidStreamField("logo", "invalid logo url")
+      if urlparse(kwargs['logo']).scheme not in ['http', 'https']:
+        raise InvalidStreamField("logo", "unsupported protocol/scheme in logo url")

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,5 +38,6 @@ types-ujson==5.8.0.1
 types-urllib3==1.26.25.14
 upnpy==1.1.8
 uvicorn==0.20.0
+validators==0.20
 wrapt==1.14.1
 zeroconf==0.47.1

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -762,9 +762,23 @@ def internetradio_urls():
     "https://www.example.co.uk": True,
     "https://subdomain.example.com/path/to/page": True,
     "http://sub.domain.example.com": True,
-    "ftp://www.example.com": False,
-    "http://www.example": False,
+    "http://example.com:8383": True,
+    "https://example.com:8383": True,
+    "http://example.com:80/with_path": True,
+    "http://sub.example.com:80/": True,
+    # the `validators` package in 0.33 has a `consider_tlds` param that
+    # allows us to check against a valid list of TLDs, but since we cannot
+    # upgrade to that version and can't check TLDs this could actually be
+    # a valid URL. Additionally, home networks sometimes have their own TLD,
+    # so it's unclear if we should ever use that functionality anyways.
+    # Version 0.33 is only available in Python >3.8
+    "http://www.example": True,
+    # Hostnames can be statically defined in `/etc/hosts`, but until
+    # someone asks for this it should probably fail validation.
     "https://example": False,
+    "http://example.com:80:80": False,
+    "https://sub.example.com:8000:/path": False,
+    "ftp://www.example.com": False,
       }.items()
 
 


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR does less obtuse and more thorough checking of internet radio URLs by farming the validation logic out to a library, whose sole job is to validate inputs.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] Have you written new tests for your core features/changes, as applicable?
* [ ] If this is a UI change, have you tested it across multiple browser platforms?
* [ ] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
