### PR TITLE
Fixup Airplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * System
   * Fixed a bug where support tunnel addresses would be served when querying for amplipi.local
   * Stream validation for URLs has been made more robust
+  * Minor bugfixes with Airplay 1 stream handling
 
 ## 0.4.2
 * Streams

--- a/amplipi/mpris.py
+++ b/amplipi/mpris.py
@@ -144,10 +144,12 @@ class MPRIS:
   def close(self):
     """Closes the MPRIS object."""
 
-    self.metadata_process.terminate()
-    if self.metadata_process.wait(1) != 0:
-      logger.info('Failed to stop MPRIS metadata process, killing')
-      self.metadata_process.kill()
+    if self.metadata_process:
+      self.metadata_process.terminate()
+      if self.metadata_process.wait(1) != 0:
+        logger.info('Failed to stop MPRIS metadata process, killing')
+        self.metadata_process.kill()
+      self.metadata_process.communicate()
 
     self.metadata_process = None
 
@@ -159,6 +161,8 @@ class MPRIS:
 
     try:
       os.remove(self.metadata_path)
+    except FileNotFoundError:
+      pass
     except Exception as e:
       logger.exception(f'Could not remove metadata file: {e}')
     logger.info(f'Closed MPRIS {self.service_suffix}')


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR has a handful of small fixes for the Airplay stream type. The biggest one is actually logging `shairport-sync` logs; there are also some process handling fixes, and migrating certain file manipulation tasks from `os.system` to native Python for interop reasons.

This was in support of #858 but does not appear to actually fix it. However, the logs being present (along with #828 ) actually give us an opportunity to maybe spot and solve this interesting and somewhat rare edgecase.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
