### PR TITLE
Do not do validation on stream configs loaded from disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   * Stream validation for URLs has been made more robust
   * Minor bugfixes with Airplay 1 stream handling
   * Reset API password, support tunnels during factory reset
+Streams
+  * Fixed a bug where streams would disappear during upgrades by disabling validation when loading from disk
 
 ## 0.4.2
 * Streams

--- a/amplipi/ctrl.py
+++ b/amplipi/ctrl.py
@@ -338,7 +338,7 @@ class Api:
       assert stream.id is not None
       if stream.id:
         try:
-          self.streams[stream.id] = amplipi.streams.build_stream(stream, self._mock_streams)
+          self.streams[stream.id] = amplipi.streams.build_stream(stream, self._mock_streams, validate=False)
           # If we're in LMS mode, we need to start these clients on each boot, not when they get assigned to a
           # particular source; the client+server connection bootstrapping takes a while, which is a less than ideal
           # user experience.

--- a/amplipi/streams/__init__.py
+++ b/amplipi/streams/__init__.py
@@ -62,27 +62,27 @@ AnyStream = Union[RCA, AirPlay, Spotify, InternetRadio, DLNA, Pandora, Plexamp,
                   Aux, FilePlayer, FMRadio, LMS, Bluetooth, MediaDevice]
 
 
-def build_stream(stream: models.Stream, mock=False) -> AnyStream:
+def build_stream(stream: models.Stream, mock: bool = False, validate: bool = True) -> AnyStream:
   """ Build a stream from the generic arguments given in stream, discriminated by stream.type
 
   we are waiting on Pydantic's implemenatation of discriminators to fully integrate streams into our model definitions
   """
   # pylint: disable=too-many-return-statements
   args = stream.dict(exclude_none=True)
-  name = args.pop('name')
+  name: str = args.pop('name')
   disabled = args.pop('disabled', False)
   if stream.type == 'rca':
     return RCA(name, args['index'], disabled=disabled, mock=mock)
   if stream.type == 'pandora':
-    return Pandora(name, args['user'], args['password'], station=args.get('station', None), disabled=disabled, mock=mock)
+    return Pandora(name, args['user'], args['password'], station=args.get('station', None), disabled=disabled, mock=mock, validate=validate)
   if stream.type in ['shairport', 'airplay']:  # handle older configs
-    return AirPlay(name, args.get('ap2', False), disabled=disabled, mock=mock)
+    return AirPlay(name, args.get('ap2', False), disabled=disabled, mock=mock, validate=validate)
   if stream.type == 'spotify':
-    return Spotify(name, disabled=disabled, mock=mock)
+    return Spotify(name, disabled=disabled, mock=mock, validate=validate)
   if stream.type == 'dlna':
     return DLNA(name, disabled=disabled, mock=mock)
   if stream.type == 'internetradio':
-    return InternetRadio(name, args['url'], args.get('logo'), disabled=disabled, mock=mock)
+    return InternetRadio(name, args['url'], args.get('logo'), disabled=disabled, mock=mock, validate=validate)
   if stream.type == 'plexamp':
     return Plexamp(name, args['client_id'], args['token'], disabled=disabled, mock=mock)
   if stream.type == 'aux':

--- a/amplipi/streams/airplay.py
+++ b/amplipi/streams/airplay.py
@@ -27,9 +27,8 @@ class AirPlay(PersistentStream):
 
   stream_type: ClassVar[str] = 'airplay'
 
-  def __init__(self, name: str, ap2: bool, disabled: bool = False, mock: bool = False):
-    super().__init__(self.stream_type, name, disabled=disabled, mock=mock)
-    self.validate_stream(name=self.name)
+  def __init__(self, name: str, ap2: bool, disabled: bool = False, mock: bool = False, validate: bool = True):
+    super().__init__(self.stream_type, name, disabled=disabled, mock=mock, validate=validate)
     self.mpris: Optional[MPRIS] = None
     self.ap2 = ap2
     self.ap2_exists = False

--- a/amplipi/streams/airplay.py
+++ b/amplipi/streams/airplay.py
@@ -130,7 +130,7 @@ class AirPlay(PersistentStream):
       logger.exception(f'Error starting airplay MPRIS reader: {exc}')
 
   def _deactivate(self):
-    if self.mpris:
+    if 'mpris' in self.__dir__() and self.mpris:
       self.mpris.close()
     self.mpris = None
     if self._is_running():
@@ -141,7 +141,7 @@ class AirPlay(PersistentStream):
         logger.info('killing shairport-sync')
         self.proc.kill()
       self.proc.communicate()
-    if self._log_file:
+    if '_log_file' in self.__dir__() and self._log_file:
       self._log_file.close()
     if self.src:
       try:

--- a/amplipi/streams/base_streams.py
+++ b/amplipi/streams/base_streams.py
@@ -49,7 +49,7 @@ class Browsable:
 class BaseStream:
   """ BaseStream class containing methods that all other streams inherit """
 
-  def __init__(self, stype: str, name: str, only_src=None, disabled: bool = False, mock=False):
+  def __init__(self, stype: str, name: str, only_src=None, disabled: bool = False, mock: bool = False, validate: bool = True, **kwargs):
     self.name = name
     self.disabled = disabled
     self.proc: Optional[subprocess.Popen] = None
@@ -59,6 +59,8 @@ class BaseStream:
     self.state = 'disconnected'
     self.stype = stype
     self.browsable = isinstance(self, Browsable)
+    if validate:
+      self.validate_stream(name=name, mock=mock, **kwargs)
 
   def __del__(self):
     self.disconnect()
@@ -154,8 +156,8 @@ class BaseStream:
     raise NotImplementedError()
 
   def validate_stream(self, **kwargs):
-    """ Validate fields """
-    raise NotImplementedError()
+    """ Validate fields. If we have not implemented a validator, simply pass validation. """
+    return True
 
 
 class VirtualSources:
@@ -190,8 +192,8 @@ vsources = VirtualSources(12)
 class PersistentStream(BaseStream):
   """ Base class for streams that are able to persist without a direct connection to an output """
 
-  def __init__(self, stype: str, name: str, disabled: bool = False, mock=False):
-    super().__init__(stype, name, None, disabled, mock)
+  def __init__(self, stype: str, name: str, disabled: bool = False, mock: bool = False, validate: bool = True, **kwargs):
+    super().__init__(stype, name, None, disabled, mock, validate, **kwargs)
     self.vsrc: Optional[int] = None
     self._cproc: Optional[subprocess.Popen] = None
     self.device: Optional[str] = None

--- a/amplipi/streams/base_streams.py
+++ b/amplipi/streams/base_streams.py
@@ -242,7 +242,7 @@ class PersistentStream(BaseStream):
       raise Exception(f'Failed to deactivate {self.name}: {e}') from e
     finally:
       self.state = "disconnected"  # make this look like a normal stream for now
-      if self.vsrc:
+      if 'vsrc' in self.__dir__() and self.vsrc:
         vsrc = self.vsrc
         self.vsrc = None
         vsources.free(vsrc)
@@ -292,7 +292,7 @@ class PersistentStream(BaseStream):
 
   def disconnect(self):
     """ Disconnect from a DAC """
-    if self._cproc:
+    if '_cproc' in self.__dir__() and self._cproc:
       logger.info(f'  stopping connection {self.vsrc} -> {self.src}')
       try:
         # must use terminate as kill() cannot be intercepted

--- a/amplipi/streams/internet_radio.py
+++ b/amplipi/streams/internet_radio.py
@@ -17,11 +17,10 @@ class InternetRadio(BaseStream):
 
   stream_type: ClassVar[str] = 'internetradio'
 
-  def __init__(self, name: str, url: str, logo: Optional[str], disabled: bool = False, mock: bool = False):
-    super().__init__(self.stream_type, name, disabled=disabled, mock=mock)
+  def __init__(self, name: str, url: str, logo: Optional[str], disabled: bool = False, mock: bool = False, validate: bool = True):
+    super().__init__(self.stream_type, name, disabled=disabled, mock=mock, validate=validate, url=url, logo=logo)
     self.url = url
     self.logo = logo
-    self.validate_stream(url=self.url, logo=self.logo)
     self.supported_cmds = ['play', 'stop']
 
   def reconfig(self, **kwargs):

--- a/amplipi/streams/pandora.py
+++ b/amplipi/streams/pandora.py
@@ -16,8 +16,8 @@ class Pandora(PersistentStream, Browsable):
 
   stream_type: ClassVar[str] = 'pandora'
 
-  def __init__(self, name: str, user, password: str, station: str, disabled: bool = False, mock: bool = False):
-    super().__init__(self.stream_type, name, disabled=disabled, mock=mock)
+  def __init__(self, name: str, user, password: str, station: str, disabled: bool = False, mock: bool = False, validate: bool = True):
+    super().__init__(self.stream_type, name, disabled=disabled, mock=mock, validate=validate, user=user, password=password)
     self.user = user
     self.password = password
     self.station = station
@@ -37,8 +37,6 @@ class Pandora(PersistentStream, Browsable):
       "PARTNER_PASSWORD": "AC7IBG09A3DTSYM4R41UJWL07VLN8JI7",
       "DEVICE": "android-generic",
     }).build()
-
-    self.validate_stream(user=self.user, password=self.password)
 
     self.ctrl = ''  # control fifo location
     self.supported_cmds = {
@@ -283,8 +281,8 @@ class Pandora(PersistentStream, Browsable):
       raise InvalidStreamField("password", "password cannot be empty")
 
     # don't run if testing so we don't cause problems with CI
-    if not self.mock:
+    if not self.mock and 'user' in kwargs and 'password' in kwargs:
       try:
-        self.pyd_client.login(self.user, self.password)
+        self.pyd_client.login(kwargs['user'], kwargs['password'])
       except Exception as e:
         raise InvalidStreamField("password", "invalid password or unable to connect to Pandora servers") from e

--- a/amplipi/streams/spotify.py
+++ b/amplipi/streams/spotify.py
@@ -13,9 +13,8 @@ class Spotify(PersistentStream):
 
   stream_type: ClassVar[str] = 'spotify'
 
-  def __init__(self, name: str, disabled: bool = False, mock: bool = False):
-    super().__init__(self.stream_type, name, disabled=disabled, mock=mock)
-    self.validate_stream(name=self.name)
+  def __init__(self, name: str, disabled: bool = False, mock: bool = False, validate: bool = True):
+    super().__init__(self.stream_type, name, disabled=disabled, mock=mock, validate=validate)
     self.connect_port: Optional[int] = None
     self.mpris: Optional[MPRIS] = None
     self.supported_cmds = ['play', 'pause', 'next', 'prev']

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -479,7 +479,7 @@ def _install_os_deps(env, progress, deps=_os_deps.keys()) -> List[Task]:
       _to = f"{env['base_dir']}/{_to}"
     _sudo = "sudo " if 'sudo' in file else ""
     _parent_dir = pathlib.Path(_to).parent
-    if not _parent_dir.exists():
+    if _sudo or not _parent_dir.exists():
       tasks += print_progress([Task(f"creating parent dir(s) for {_from}", f"{_sudo}mkdir -p {_parent_dir}".split()).run()])
     tasks += print_progress([Task(f"copy -f {_from} to {_to}", f"{_sudo}cp -f {_from} {_to}".split()).run()])  # shairport needs the -f if it is running
   if env['is_amplipi'] or env['is_ci']:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,0 +1,17 @@
+import pytest
+import context
+
+def test_validation_switched_off():
+  # AirPlay names can only be 50chars long; test that this obj can be created without validation
+  # enabled, and that it does do validation normally
+  kwargs = {
+    'name': 'a'*51,
+    'mock': True,
+    'ap2': False,
+  }
+  assert context.amplipi.streams.AirPlay(validate=False, **kwargs)
+
+  with pytest.raises(context.amplipi.streams.base_streams.InvalidStreamField):
+    context.amplipi.streams.AirPlay(**kwargs)
+
+


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR fixes #875 by disabling validation for stream configs loaded from disk. Editing an "invalid" stream will still produce an error indicating how it is failing validation, which potentially allows us to fix streams going forward without wiping invalid configs from disk; more or less, validation happens in every other case.

~I get that changing the function signatures to capture and pass around **kwargs is a little less than rigorious, but [there are tools to type this dict in modern Python](https://typing.readthedocs.io/en/latest/spec/callables.html#unpack-kwargs) to add some rigor, and it's definitely flexy. Lemme know if that feels too messy though - I can simply only input the `validate` param in the `build_streams` cases where it's used too, np.~ edit: I made this more straightforward and touch less LOC, feel decent bout it. 

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] Have you written new tests for your core features/changes, as applicable?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
