### PR TITLE
Fix lms port edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Change "<- Back to App" button on the updater page to redirect to the settings page rather than the homepage
   * Update links on "About" settings tab to open in a new tab
   * Add scroll functionality to more modals, hide the scrollbars
+  * Handle errors better in the stream editing dialog
 * System
   * Fixed a bug where support tunnel addresses would be served when querying for amplipi.local
   * Stream validation for URLs has been made more robust

--- a/amplipi/streams/lms.py
+++ b/amplipi/streams/lms.py
@@ -37,7 +37,7 @@ class LMS(PersistentStream):
     if 'server' in kwargs and kwargs['server'] != self.server:
       self.server = kwargs['server']
       reconnect_needed = True
-    if 'port' in kwargs and kwargs['port'] != self.port:
+    if 'port' in kwargs and kwargs['port'] != self.port and kwargs['port']:
       self.port = kwargs['port']
       reconnect_needed = True
     if reconnect_needed:

--- a/web/src/pages/Settings/Streams/StreamModal/StreamModal.jsx
+++ b/web/src/pages/Settings/Streams/StreamModal/StreamModal.jsx
@@ -237,7 +237,13 @@ const StreamModal = ({ stream, onClose, apply, del }) => {
                         return;
                     }
                 }
-                apply(streamFields).then((response)=>{
+                // Omit any fields that are simply empty. This permits Pydantic to cast to None,
+                // and then our constructors et al use their defaults.
+                // ref: https://github.com/pydantic/pydantic/discussions/2687
+                const filteredStreamFields = Object.fromEntries(
+                    Object.entries(streamFields).filter( ([key, value]) => value !== "" )
+                );
+                apply(filteredStreamFields).then((response)=>{
                     if(response.ok)
                     {
                         setErrorField("");

--- a/web/src/pages/Settings/Streams/StreamModal/StreamModal.jsx
+++ b/web/src/pages/Settings/Streams/StreamModal/StreamModal.jsx
@@ -256,8 +256,18 @@ const StreamModal = ({ stream, onClose, apply, del }) => {
                             setErrorMessage(error.detail);
                         }
                         else if(typeof error.detail === "object"){
-                            setErrorField(error.detail.field);
-                            setErrorMessage(error.detail.msg);
+                            // We use the 'field' member to report an invalid field during stream validation,
+                            // but this isn't present on simple Pydantic model errors
+                            if(error.detail.field) {
+                                setErrorField(error.detail.field);
+                                setErrorMessage(error.detail.msg);
+                            } else if(error.detail[0]) {
+                                setErrorField(error.detail[0].loc[1]);
+                                // example: 'port: not a valid integer'
+                                setErrorMessage(`${error.detail[0].loc[1]}: ${error.detail[0].msg}`);
+                            } else {
+                                setErrorMessage("Unknown error");
+                            }
                         }
                         else{
                             setErrorMessage("Unknown error");


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR fixes up some of the rough edges around stream editing; this was brought up via editing LMS to remove the port from the config. 

There are two commits here. The first handles API errors in the frontend much more robustly, following the InvalidField conventions but for Pydantic generated errors. This is somewhat less than ideal, but seems robust enough for right now.

The second is legitimately an interface change and might deserve some further testing. This commit omits all "" members from an object we will PATCH to the API. This allows Pydantic to actually handle the `Optional` case in a relatively Pythonic way. I've linked a reference to a Pydantic issue. Lemme know your gut read on this and if it's at all sketchy I can rip it out or extensively test.

This PR fixes #878 .

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [ ] Have you written new tests for your core features/changes, as applicable?
* [ ] If this is a UI change, have you tested it across multiple browser platforms?