### PR TITLE
Disallow running multiple FM or Bluetooth streams at once in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * Handle errors better in the stream editing dialog
   * Migrate more components to mui, a Material UI implementation
   * Add marquee functionality the header of all modals, if the header text doesn't fit it will now scroll instead of pushing all the content down
+  * Only allow one FM or Bluetooth stream to run at once
 * System
   * Fixed a bug where support tunnel addresses would be served when querying for amplipi.local
   * Stream validation for URLs has been made more robust

--- a/amplipi/streams/bluetooth.py
+++ b/amplipi/streams/bluetooth.py
@@ -64,7 +64,7 @@ class Bluetooth(BaseStream):
     return
 
   def _is_running(self):
-    if self.bt_proc:
+    if 'bt_proc' in self.__dir__() and self.bt_proc:
       return self.bt_proc.poll() is None
     return False
 

--- a/amplipi/streams/fm_radio.py
+++ b/amplipi/streams/fm_radio.py
@@ -58,7 +58,7 @@ class FMRadio(BaseStream):
     self._connect(src)
 
   def _is_running(self):
-    if self.proc:
+    if 'proc' in self.__dir__() and self.proc:
       return self.proc.poll() is None
     return False
 


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR prevents running multiple FM stations or Bluetooth streams at the same time in the UI. (This is a bit of a misnomer for Bluetooth, as there is only ever one stream definition turned on or off anyways, but I handle that anyways for the future.) There's also some helper bits in the backend stream defs for these - `proc` & `bt_proc` are not present/set in the constructor, so `_is_running()` can exception if called before `connect()` is. (I intended to solve this in the backend, but leaving this to implement in client code is not the end of the world for now.) That means this is probably only half of #857 , but that second half can get punted much further into the future, especially considering we have aspirations of rewriting the stream scaffolding.

One thing to call out is [the use of `structuredClone`](https://caniuse.com/?search=structuredClone), just cuz it's so new. I added #900 regardless if `structuredClone` is in or out, because that will help folks have a good user experience.

It looks like this:
![Screenshot from 2024-08-20 17-28-18](https://github.com/user-attachments/assets/d894cd43-f373-4f27-af74-41d4ed813a1c)

I've tested in Firefox, still gotta try other platforms.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [ ] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [ ] Have you written new tests for your core features/changes, as applicable?
* [ ] If this is a UI change, have you tested it across multiple browser platforms?
* [ ] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
