### PR TITLE
Move and backup primary config during upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   * Stream validation for URLs has been made more robust
   * Minor bugfixes with Airplay 1 stream handling
   * Reset API password, support tunnels during factory reset
+  * Actually move system state to .config/amplipi
+  * Take a local config backup during every firmware upgrade
 Streams
   * Fixed a bug where streams would disappear during upgrades by disabling validation when loading from disk
 

--- a/amplipi/models.py
+++ b/amplipi/models.py
@@ -24,6 +24,7 @@ from functools import lru_cache
 from typing import List, Dict, Optional, Union, Set
 from types import SimpleNamespace
 from enum import Enum
+from pathlib import Path
 
 # pylint: disable=no-name-in-module
 from pydantic import BaseSettings, BaseModel, Field
@@ -1364,7 +1365,7 @@ class AppSettings(BaseSettings):
   """ Controller settings """
   mock_ctrl: bool = True
   mock_streams: bool = True
-  config_file: str = 'house.json'
+  config_file: str = str(Path.home() / '.config' / 'amplipi' / 'house.json')
   delay_saves: bool = True
 
 

--- a/docs/manual/TROUBLESHOOTING.md
+++ b/docs/manual/TROUBLESHOOTING.md
@@ -43,9 +43,12 @@ Manual backups are taken by navigating to ⚙ -> Config -> Download Config. This
 
 ### Automated system backups and restores
 
-Automated backups are also taken nightly at 2AM and stored for 30 days. These are raw system backups, accessible only by an advanced user via the backend. These backups help either support, or a technical user, to restore prior system configuration from a particular point in time. If the below instructions do not make sense to you, you should feel free to email [support@micro-nova.com](mailto:support@micro-nova.com) and we can help restore a backup from your appliance.
+Automated backups are also taken nightly at 2AM and stored for 90 days, and also whenever you upgrade to a newer version of software. These are raw system backups, accessible only by an advanced user via the backend. These backups help either support, or a technical user, to restore prior system configuration from a particular point in time. If the below instructions do not make sense to you, you should feel free to email [support@micro-nova.com](mailto:support@micro-nova.com) and we can help restore a backup from your appliance.
 
-These backups are dated tarballs stored at `~pi/backups`. This tarball contains the entire `~pi/.config/amplipi` directory. To restore this backup, stop the AmpliPi service (`systemctl stop --user amplipi` as the `pi` user), unpack the tarball, overwrite the `~pi/.config/amplipi` directory with the contents of the backup, and start AmpliPi again (`systemctl start --user amplipi`).`
+These backups are dated tarballs stored at `/home/pi/backups`. This tarball contains the entire `/home/pi/.config/amplipi` directory. To restore this backup:
+1. Stop the AmpliPi service (`systemctl stop --user amplipi` as the `pi` user).
+1. Unpack a backup tarball and overwrite the contents of `.config/amplipi` (something like `tar --force-local -xvzf backups/config_2024-08-22T12:42:31-04:00_pre-fw-upgrade.tgz -C /`).  Here we use `config_2024-08-22T12:42:31-04:00_pre-fw-upgrade.tgz` as an example backup file. 
+1. Start AmpliPi again (`systemctl start --user amplipi`).`
 
 ## Reimaging AmpliPro
 For directions on how to bring AmpliPro system back to a previous version, scan the QR labeled "Reimaging Instructions" on the links page at the start of this manual, or [click this link](https://github.com/micro-nova/AmpliPi/blob/main/docs/imaging_etcher.md). It is a good idea to take a system backup before running this process; see the above section labelled "Taking and restoring configuration backups".

--- a/scripts/backup_config.sh
+++ b/scripts/backup_config.sh
@@ -2,12 +2,13 @@
 
 date="$(date --iso-8601='seconds')"
 backup_dir="${HOME}/backups"
-backup_filename="${backup_dir}/config_backup-${date}.tgz"
+suffix="${1}"
+backup_filename="${backup_dir}/config_${date}${suffix}.tgz"
 
 echo "taking a config backup..."
 mkdir -p "${backup_dir}"
 tar --one-file-system -czf "${backup_filename}" "${HOME}/.config/amplipi/"
 
-# remove all backups older than 30 days
+# remove all backups older than 90 days
 echo "removing old backups..."
-find "${backup_dir}" -type f -ctime +30 -delete
+find "${backup_dir}" -type f -ctime +90 -delete

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -195,8 +195,6 @@ $fw && opts="$opts --firmware"
 $pw && opts="$opts --password"
 $deps && opts="$opts --os-deps --python-deps"
 ssh $user_host -t "python3 amplipi-dev/scripts/configure.py --web --restart-updater --display --audiodetector$opts" || echo ""
-echo "Deleting tarball at ${release_name}.tar.gz"
-ssh $user_host "rm ${release_name}.tar.gz"
 
 printf "Waiting for AmpliPi to restart"
 restart_finished=false
@@ -227,6 +225,8 @@ if $restart_finished; then
   if ! $amplipi_found; then
     printf "\nFailed to detect ${host}/api.\n"
   fi
+  echo "Deleting tarball at ${release_name}.tar.gz"
+  ssh $user_host "rm ${release_name}.tar.gz"
 else
   echo "Restart failed."
 fi


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR actually accomplishes #804 - the prior fix was incomplete. I'm filing this now but intend to do a bunch of testing tomorrow to make sure this does exactly what it says on the tin. This fixes #902 .

This PR also takes a backup of the config during _every_ upgrade. This would have saved us a lot of grief, and the script to make said backup is already in our repo - just need to trigger it during upgrades. 

### Checklist

* [x] Have you tested your changes and ensured they work? Yes, but I intend to poke at this more too.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`