### PR TITLE
Fix cropped settings heading with a small viewport height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Add marquee functionality the header of all modals, if the header text doesn't fit it will now scroll instead of pushing all the content down
   * Only allow one FM or Bluetooth stream to run at once
   * Change how errors are displayed on Stream create/edit modal to be more obvious
+  * Fix a bug where UI content was cropped on certain mobile platforms
 * System
   * Fixed a bug where support tunnel addresses would be served when querying for amplipi.local
   * Stream validation for URLs has been made more robust

--- a/web/src/pages/Settings/Settings.scss
+++ b/web/src/pages/Settings/Settings.scss
@@ -39,7 +39,7 @@
 
 .settings-page-container {
   background-color: general.$bg;
-  height: 100vh;
+  height: 100svh;
   width: 100vw;
 }
 


### PR DESCRIPTION
### What does this change intend to accomplish?
This PR fixes #898 by using a [small viewport height](https://dev.to/frehner/css-vh-dvh-lvh-svh-and-vw-units-27k4), to tolerate various notches and safe areas on things like cellphones.

This works on my iPhone 12 Mini, which is what illuminated #898 in the first place. I'm testing it elsewhere now.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] If applicable, have you updated the documentation/manual?
* [x] If applicable, have you updated the CHANGELOG?
* [ ] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [ ] Have you written new tests for your core features/changes, as applicable?
* [x] If this is a UI change, have you tested it across multiple browser platforms?
* [x] If this is a UI change, have you tested across multiple viewport sizes (ie. desktop versus mobile)?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
