### PR TITLE
Implement `HeaderMarquee` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Fix a bug where UI content was cropped on certain mobile platforms
   * Ensure that media device audio streams stop outputting audio when disconnected
   * Limit max height of group creation dropdown
+  * Improve how marquee components look when not scrolling
 * System
   * Fixed a bug where support tunnel addresses would be served when querying for amplipi.local
   * Stream validation for URLs has been made more robust

--- a/web/src/components/CustomMarquee/CustomMarquee.jsx
+++ b/web/src/components/CustomMarquee/CustomMarquee.jsx
@@ -3,7 +3,7 @@ import Marquee from "react-fast-marquee";
 
 import PropTypes from "prop-types";
 
-function CustomMarquee(props) {
+export default function CustomMarquee(props) {
     const {
         children,
         containerRef,
@@ -31,47 +31,56 @@ function CustomMarquee(props) {
             // The boolean is set to true by the timer within the if statement, and set to false whenever a marquee scroll cycle completes
 
             if(container.offsetWidth < scroll.scrollWidth && !marqueeScroll){
-                // If the content does not fit the div, and if the scroll is not paused, start scrolling after a two second timer
+                // If the content does not fit the div, and if the scroll is paused, start scrolling after a two second timer
                 // The timer is used to create a pause effect, keep the data from simply scrolling infinitely
                 scrollPause.current = setTimeout(()=>{setScroll(true)}, 2000);
             } else {
                 // if content is not meant to scroll, remove the timer that allows it to start scrolling again
-                // This is useful in cases when the screen is resized or the song changes during a pause phase
+                // This is useful in cases when the screen is resized during a pause phase
                 clearTimeout(scrollPause.current);
             }
         }
     }
 
-    setTimeout(()=>{assessMarquee();}, 2000) // used to kick off useEffect after two seconds of page load
-
-
+    let resizeTimout;
     function handleResize(){
         if(!resizeCooldown.current){
             resizeCooldown.current = true;
 
             assessMarquee()
 
-            setTimeout(()=>{resizeCooldown.current = false;}, 1000) // set a cooldown for resize checks to avoid excessive renders
+            resizeTimout = setTimeout(()=>{resizeCooldown.current = false;}, 1000) // set a cooldown for resize checks to avoid excessive renders
         }
     }
     window.addEventListener("resize", handleResize()); // Doesn't call assessMarquee directly to avoid calling thousands of times per second when resizing window
 
+    React.useEffect(() => {
+        setScroll(false);
+        assessMarquee();
+    }, [children])
 
-    return(
-        <Marquee play={marqueeScroll} speed={30} onCycleComplete={() => {setScroll(false); assessMarquee();}}>
+    if(marqueeScroll){
+        return(
+            <Marquee play={marqueeScroll} speed={30} onCycleComplete={() => {setScroll(false); assessMarquee();}}>
             <div
-                style={{marginLeft: "10px"}} //Needs inline styling for margin to add a gap between start and end of marquee, also keeps marquee from "overscrolling" (stopping a pixel or two after reaching the wraparound point due to minor lag)
-                className="marquee-text"
+                style={{marginRight: "25px"}} // Uses right margin to provide a gap between the start and end of scroll but without effecting the center align of non-scrolling data
                 ref={childrenRef}
             >
                 {children}
             </div>
-        </Marquee>
-    )
+            </Marquee>
+        )
+    } else {
+        return(
+            <div
+                ref={childrenRef}
+            >
+                {children}
+            </div>
+        )
+    }
 };
 CustomMarquee.propTypes = {
     children: PropTypes.string.isRequired,
     containerRef: PropTypes.object.isRequired, // Needs to be a React.useRef specifically, but proptypes doesn't let you specify that
 };
-
-export default CustomMarquee;

--- a/web/src/components/CustomMarquee/CustomMarquee.scss
+++ b/web/src/components/CustomMarquee/CustomMarquee.scss
@@ -1,3 +1,0 @@
-.marquee-text {
-  margin-left: 5px !important; // Prevents marquee text from stopping in the improper location occasionally
-}

--- a/web/src/components/ModalCard/ModalCard.scss
+++ b/web/src/components/ModalCard/ModalCard.scss
@@ -21,6 +21,8 @@
   margin-bottom: 0;
   font-size: 2.5rem;
   text-align: center;
+  width: 100%;
+  white-space: nowrap;
 }
 
 .modal-body {

--- a/web/src/components/SongInfo/SongInfo.scss
+++ b/web/src/components/SongInfo/SongInfo.scss
@@ -5,6 +5,11 @@
   flex-direction: column;
   justify-content: center;
   text-shadow: 1px 2px 3px #000000;
+  padding-left: 5px;
+  padding-right: 5px;
+
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .artist-name {

--- a/web/src/components/StreamBar/StreamBar.scss
+++ b/web/src/components/StreamBar/StreamBar.scss
@@ -19,10 +19,12 @@
 .stream-bar-name {
   padding-left: 5px;
   color: general.$text-color;
+  width: 100%;
   max-width: 80%; // Leave space for icon
   font-size: 2.5rem;
   font-weight: medium;
-  text-wrap: nowrap;
+  white-space: nowrap;
+  overflow: hidden;
   @include general.header-font;
   padding: 0.5rem;
 }

--- a/web/src/pages/Player/Player.jsx
+++ b/web/src/pages/Player/Player.jsx
@@ -71,11 +71,6 @@ const Player = () => {
                     onClose={() => setStreamsModalOpen(false)}
                 />
             )}
-            <div className="stream-title" >
-                <Chip>
-                    <StreamBar sourceId={selectedSourceId} onClick={() => {setStreamsModalOpen(true);}}/>
-                </Chip>
-            </div>
             <Grid
               container
               direction="column"
@@ -83,21 +78,15 @@ const Player = () => {
               alignItems="center"
             >
                 <Grid item xs={2} sm={4} md={4}>
-                    <img src={img_url} className="player-album-art" />
+                    <div className="stream-title" >
+                        <Chip style={{width: "100%"}}>
+                            <StreamBar sourceId={selectedSourceId} onClick={() => {setStreamsModalOpen(true);}}/>
+                        </Chip>
+                    </div>
                 </Grid>
-                <Grid item xs={6} sm={6} md={6} >
-                    <Grid
-                        container
-                        direction="row"
-                        justifyContent="center"
-                        alignItems="center"
-                        >
-                            <Grid item xs={0} sm={2} md={3}> {/* Spacer */} </Grid>
-                            <Grid item xs={12} sm={8} md={6}>
-                                <SongInfo sourceId={selectedSourceId} />
-                            </Grid>
-                            <Grid item xs={0} sm={2} md={3}> {/* Spacer */} </Grid>
-                        </Grid>
+                <Grid item xs={2} sm={4} md={4} style={{maxWidth: "22rem"}}>
+                    <img src={img_url} className="player-album-art" />
+                    <SongInfo sourceId={selectedSourceId} />
                 </Grid>
                 <Grid item xs={2} sm={4} md={4}>
                     <MediaControl selectedSource={selectedSourceId} />

--- a/web/src/pages/Player/Player.scss
+++ b/web/src/pages/Player/Player.scss
@@ -13,6 +13,7 @@
 .stream-title {
   cursor: pointer;
   @include general.button-hover;
+  width: 100%;
 }
 
 .player-inner {


### PR DESCRIPTION
### What does this change intend to accomplish?
Closes #906, #915, #916 by creating a version of marquee that reinitializes with every scroll, and isn't a marquee unless it needs to be. This makes it so that `ReactFastMarquee` doesn't negatively impact our formatting, and reduces the number of edge cases where scrolling goes a little silly when the thing that's scrolling changes

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
