### PR TITLE
Add error catching to browse page fetch requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.5
 * Web App
   * Ensure that abnormally-shaped album art is still horizontally centered
+  * Add error handling on browser page for instances where the selected stream isn't browsable
 
 ## 0.4.4
 * Web App

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -531,7 +531,8 @@ def browse_stream(selection: Optional[models.BrowserSelection] = None, ctrl: Api
   stream = ctrl.streams[sid]
   if stream is None:
     raise HTTPException(404, f'source {sid} not found')
-  elif not stream.browsable:
+
+  if not stream.browsable:
     raise HTTPException(404, f'source {sid} is not browsable')
 
   if selection is not None:

--- a/web/src/components/StatusBars/ResponseBar.jsx
+++ b/web/src/components/StatusBars/ResponseBar.jsx
@@ -18,7 +18,7 @@ export default function ResponseBar(props) {
         if(response != null){
             try {
                 const res = await response;
-                if (res.ok) {
+                if (res.ok && successText !== null) {
                     setSuccess(true);
                     text.current = successText;
                 } else {
@@ -48,7 +48,7 @@ export default function ResponseBar(props) {
     );
 }
 ResponseBar.propTypes = {
-    successText: PropTypes.string.isRequired,
+    successText: PropTypes.string,
     response: PropTypes.instanceOf(Promise).isRequired,
 };
 


### PR DESCRIPTION
### What does this fix?
There was a React error on the browse page when you either didn't have a stream selected, or selected a non-browsable stream and still got there (either by you browsing a stream another user closed, or had a bookmark for, or however else you'd choose to access that url when the direct link is unavailable).
React errors are serious problems as they require the mobile app to restart to be able to continue operating the device, this PR aims to give a device error instead by obviating the backend error into the frontend without React being bothered along the way

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
