### PR TITLE
Horizontally center album art

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # AmpliPi Software Releases
 
+## 0.4.5
+* Web App
+  * Ensure that abnormally-shaped album art is still horizontally centered
+
+## 0.4.4
+* Web App
+  * Ensure that media device audio streams stop outputting audio when disconnected
+  * Limit max height of group creation dropdown
+  * Improve how marquee components look when not scrolling
+
 ## 0.4.3
 * Web App
   * Fix internet radio search on IOS app

--- a/web/src/pages/Player/Player.jsx
+++ b/web/src/pages/Player/Player.jsx
@@ -16,6 +16,7 @@ import { getSourceInputType } from "@/utils/getSourceInputType";
 import Chip from "@/components/Chip/Chip";
 import Grid from "@mui/material/Grid/Grid"
 import selectActiveSource from "@/utils/selectActiveSource";
+import Box from "@mui/material/Box/Box";
 
 import { getSourceZones } from "@/pages/Home/Home";
 
@@ -85,7 +86,15 @@ const Player = () => {
                     </div>
                 </Grid>
                 <Grid item xs={2} sm={4} md={4} style={{maxWidth: "22rem"}}>
-                    <img src={img_url} className="player-album-art" />
+                    <Box
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'center',
+                          alignItems: 'center',
+                        }}
+                    >
+                        <img src={img_url} className="player-album-art" />
+                    </Box>
                     <SongInfo sourceId={selectedSourceId} />
                 </Grid>
                 <Grid item xs={2} sm={4} md={4}>


### PR DESCRIPTION
### What does this change intend to accomplish?
See video for before, after, and proof that this doesn't bother standard album art

@linknum23 found that some internet radio stations provide a logo that isn't a square, and since we use internet radio logos as their album art that made it display strangely; this PR fixes that while not effecting standard sized album art

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
