### PR TITLE
add disk image manipulation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,8 @@ docs/manual/_markdown_manual
 
 # Status File
 display-status.txt
+
+# archives and disk images
+*.img
+*.gz
+*.xz

--- a/scripts/image_testing/chroot.sh
+++ b/scripts/image_testing/chroot.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+if [ $(whoami) != "root" ] ; then
+  echo "Please run as root."
+  exit
+fi
+
+# perhaps this is the least commonly used util. perhaps not. 
+if [ "$(dpkg --get-selections qemu-user-static)" ] ; then
+  apt install binfmt-support qemu-user-static
+fi
+
+chroot root /bin/bash
+rm -v root/root/.bash_history

--- a/scripts/image_testing/flash.sh
+++ b/scripts/image_testing/flash.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# flashes an amplipi disk image to an amplipi; attempts to launch rpiboot,
+# autodetect the amplipi disk, prompt the user, flash it, and finally
+# send a terminal bell.
+
+# check user
+if [ $(whoami) != "root" ] ; then
+  echo "Please become root."
+  exit
+fi
+
+# check dependencies
+for i in whiptail rpiboot partprobe; do
+  if [ ! $(which ${i} ]; then
+    echo "Dependency ${i} not found; please install it or place it in your \$PATH"
+    exit
+  fi
+done
+
+set -u
+
+if [ -z "$(ls /dev/disk/by-id/usb-RPi*)" ]; then
+  rpiboot
+  sleep .2
+  partprobe
+fi
+
+set -e
+
+dev=$(ls /dev/disk/by-id/usb-RPi* | grep -v part)
+parts=$(ls /dev/disk/by-id/usb-RPi* | grep part)
+
+set +e
+for part in ${parts}; do
+	umount ${part}
+done
+set -e
+
+sync
+
+whiptail --yesno "is this the correct device? \n ${dev}" 10 50
+
+dd if=${1} of=${dev} bs=2M oflag=dsync status=progress
+
+echo "syncing to disk..."
+sync
+sleep 5
+
+echo "done!"
+
+# I would use `notify-send` here, but it doesn't function for me
+# in `sudo -i` 🥴
+# https://youtu.be/Dp11DjaUc5A
+tput bel

--- a/scripts/image_testing/mount.sh
+++ b/scripts/image_testing/mount.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+function help() {
+  echo "${0}: mounts an AmpliPi disk image into the relative directory 'root'"
+  echo "usage: ${0} [disk image]"
+}
+
+if [ -z ${1} ]; then
+  help
+  exit
+fi
+
+if [ $(whoami) != "root" ] ; then
+  echo "Please become root."
+  exit
+fi
+
+set -eu
+
+lo=$(losetup --find --show --partscan ${1})
+
+mkdir -p root/boot
+mount ${lo}p2 root
+mount ${lo}p1 root/boot

--- a/scripts/image_testing/umount.sh
+++ b/scripts/image_testing/umount.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ $(whoami) != "root" ] ; then
+  echo "Please become root."
+  exit
+fi
+
+set -eu
+
+sync
+umount root/boot
+umount root
+losetup -D


### PR DESCRIPTION
### What does this change intend to accomplish?
I've been gently refining these little disk image utilities for nearly a year now, and it feels time to make them a part of the actual repository here. These scripts allow one to quickly find an amplipi and flash to it; mount an image to a test dir; run applications within the image's chroot using `binfmt-support` & `qemu-user-static`, and unmount the same directory structure. 

### Checklist

* [x] Have you tested your changes and ensured they work?