### PR TITLE
InstantPolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     * Add toggleable option to persist system logs to Admin Settings
     * Move "Set password" page to be accessible via Admin Settings tab
   * Add success/fail messages to zones settings changes
+  * Add state polling to some user workflows (stream starting, stopping; using presets) to remove the illusion of lag
 * System
   * Make update process properly report errors
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -99,8 +99,8 @@ export const useStatusStore = create((set, get) => ({
         );
     },
     setBrowsableStreamSong: (streamId, itemId, setPath) => {
-        return fetch(`/api/streams/browser/${streamId}/play`, { 
-            method: "post", 
+        return fetch(`/api/streams/browser/${streamId}/play`, {
+            method: "post",
             headers: {
                 "content-type": "application/json",
             },
@@ -120,11 +120,7 @@ export const useStatusStore = create((set, get) => ({
         });
     },
 
-    fetch: () => {
-    // if (get().skipUpdate) {
-    //   set({ skipUpdate: false })
-    //   return
-    // }
+    getSystemState: () => {
         fetch("/api")
             .then((res) => {
                 if (res.ok) {
@@ -144,6 +140,9 @@ export const useStatusStore = create((set, get) => ({
             .catch(() => {
                 set({ disconnected: true });
             });
+    },
+    setSystemState: (s) => {
+        set({ status: s, loaded: true, disconnected: false });
     },
     setZoneVol: (zoneId, new_vol) => {
         set(

--- a/web/src/Poller.jsx
+++ b/web/src/Poller.jsx
@@ -10,16 +10,16 @@ const UPDATE_INTERVAL = 1500;
 const Poller = ({ children }) => {
     const isLoaded = useStatusStore((s) => s.loaded);
     const disconnected = useStatusStore((s) => s.disconnected);
-    const update = useStatusStore((s) => s.fetch);
+    const getSystemState = useStatusStore((s) => s.getSystemState);
 
     // update immediately at start
     React.useEffect(() => {
-        update();
+        getSystemState();
     }, []);
 
     // update periodically
     useInterval(() => {
-        update();
+        getSystemState();
     }, UPDATE_INTERVAL);
 
     if (!isLoaded || disconnected) {

--- a/web/src/components/PlayerCard/PlayerCardFb.jsx
+++ b/web/src/components/PlayerCard/PlayerCardFb.jsx
@@ -29,6 +29,7 @@ const PlayerCardFb = ({ sourceId, setVol }) => {
     const selected = usePersistentStore((s) => s.selectedSource) === sourceId;
     const img_url = useStatusStore((s) => s.status.sources[sourceId].info.img_url);
     const is_streamer = useStatusStore((s) => s.status.info.is_streamer);
+    const setSystemState = useStatusStore((s) => s.setSystemState);
 
     const select = () => {
         if (selected) {
@@ -60,6 +61,8 @@ const PlayerCardFb = ({ sourceId, setVol }) => {
                                         "Content-type": "application/json",
                                     },
                                     body: JSON.stringify({ input: "None" }),
+                                }).then(res => {
+                                    if(res.ok){res.json().then(s => setSystemState(s))}
                                 });
                             }}
                         >

--- a/web/src/components/PresetsModal/PresetsModal.jsx
+++ b/web/src/components/PresetsModal/PresetsModal.jsx
@@ -70,6 +70,7 @@ const PresetsModal = ({ onClose }) => {
     const [presetStates, setPresetStates] = useState(
         presets.map((preset) => {if(preset){return false;}}) // Changed this line so that preset wouldn't go unused as per eslint
     );
+    const setSystemState = useStatusStore((s) => s.setSystemState);
 
     // resize presetStates (without overriding) if length changes
     if (presetStates.length > presets.length) {
@@ -89,11 +90,12 @@ const PresetsModal = ({ onClose }) => {
         fetch(`/api/presets/${id}/load`, {
             method: "POST",
             accept: "application/json",
-        }).then(() =>
+        }).then(res => {
+            if(res.ok){res.json().then(s => setSystemState(s))}
             setPresetStates(
                 presetStates.map((state, i) => (i === index ? "done" : state))
             )
-        ).catch(() =>
+        }).catch(() =>
             setPresetStates(
                 presetStates.map((state, i) => (i === index ? false : state))
             )

--- a/web/src/components/ZonesModal/ZonesModal.jsx
+++ b/web/src/components/ZonesModal/ZonesModal.jsx
@@ -178,7 +178,7 @@ const ZonesModal = ({
     // };
 
     const setZones = () => {
-    // redefine sourceId
+        // redefine sourceId
 
         const sid = useRcaSourceId ? rcaSourceId : sourceId;
         const zs = useRcaSourceId ? rcaStatus.zones : zones;

--- a/web/src/pages/Home/Home.jsx
+++ b/web/src/pages/Home/Home.jsx
@@ -80,6 +80,7 @@ const Home = () => {
     const [streamsModalOpen, setStreamsModalOpen] = React.useState(false);
     const [presetsModalOpen, setPresetsModalOpen] = React.useState(false);
     const [streamerOutputModalOpen, setStreamerOutputModalOpen] = React.useState(false);
+    const setSystemState = useStatusStore(s => s.setSystemState);
 
     let nextAvailableSource = null;
     let cards = [];
@@ -126,14 +127,20 @@ const Home = () => {
                     sourceId={nextAvailableSource}
                     loadZonesGroups={false}
                     // on apply, we want to call
-                    onApply={executeApplyAction}
+                    onApply={async (customSourceId) => {
+                        const ret = await executeApplyAction(customSourceId);
+                        if(ret.ok){ret.json().then(s => setSystemState(s))};
+                    }}
                     onClose={() => setZonesModalOpen(false)}
                 />
             )}
             {streamerOutputModalOpen && (
                 <StreamerOutputModal
                     sourceId={nextAvailableSource}
-                    onApply={executeApplyAction}
+                    onApply={async (customSourceId) => {
+                        const ret = await executeApplyAction(customSourceId);
+                        if(ret.ok){ret.json().then(s => setSystemState(s))};
+                    }}
                     onClose={() => setStreamerOutputModalOpen(false)}
                 />
             )}


### PR DESCRIPTION
### What does this change intend to accomplish?
Closes #946
Calls the polling function whenever relevant state changes happen. For now this is just on stream creation and closing, can be extended to other things in the future as needed

Also changes the name of the polling function from `fetch` to `getSystemState` to match the convention of surrounding functions while not overshadowing the builtin javascript `fetch`
Unfortunately my typical before:after video format was too long, and breaking it up into two videos makes the before _still_ be too long so here's the after, get the before yourself on literally any AmpliPro 

After:

https://github.com/user-attachments/assets/1dbb5e72-a03a-407b-9676-b53a4943d6ea



### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
