### PR TITLE
ModalCloseSensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Ensure that abnormally-shaped album art is still horizontally centered
   * Add error handling on browser page for instances where the selected stream isn't browsable
   * Add scrollbars to tall modals
+  * Change how events are handled with Modals to reduce accidental closures
 * System
   * Make update process properly report errors
 

--- a/web/src/components/Modal/Modal.jsx
+++ b/web/src/components/Modal/Modal.jsx
@@ -1,17 +1,24 @@
 import React from "react";
-
 import "./Modal.scss";
 import StopProp from "@/components/StopProp/StopProp";
-
 import PropTypes from "prop-types";
 
 const Modal = ({ children, className = "", onClose }) => {
+    const [mouseDownOutside, setMouseDownOutside] = React.useState(false);
     return (
         <div
             className={`modal_container ${className}`}
-            onClick={(e) => {
-                onClose();
-                e.stopPropagation();
+            onMouseDown={(e) => {
+                if (e.target === e.currentTarget) {
+                    setMouseDownOutside(true);
+                } else {
+                    setMouseDownOutside(false);
+                }
+            }}
+            onMouseUp={(e) => {
+                if (mouseDownOutside && e.target === e.currentTarget) {
+                    onClose();
+                }
             }}
         >
             <StopProp>{children}</StopProp>


### PR DESCRIPTION
### What does this change intend to accomplish?
Closes #944
Deconstructs `onClick` event into `onMouseDown` and `onMouseUp` events and requires them to happen sequentially outside of Modals to reduce accidental closures when you're just trying to highlight text

https://github.com/user-attachments/assets/4117cbd9-c5c6-408a-b733-e950c6709631

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
