### PR TITLE
Persist Logs during updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AmpliPi Software Releases
 
+## 0.4.6
+* System
+  * Automatically persist logs during (and for a short time after) updates
+
 ## 0.4.5
 * Web App
   * Ensure that abnormally-shaped album art is still horizontally centered

--- a/amplipi/updater/static/index.html
+++ b/amplipi/updater/static/index.html
@@ -44,7 +44,7 @@
               <a class="nav-link" id="manual-update-tab" data-toggle="tab" href="#manual-update" role="tab" aria-controls="manual-update" aria-selected="false">Custom Update</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" id="admin-settings-tab" data-toggle="tab" href="#admin-settings" role="tab" aria-controls="admin-settings" aria-selected="false">Admin Settings</a>
+              <a class="nav-link" id="admin-settings-tab" data-toggle="tab" href="#admin-settings" role="tab" aria-controls="admin-settings" aria-selected="false" onClick="getPersist();">Admin Settings</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" id="support-tunnel-tab" data-toggle="tab" href="#support-tunnel" role="tab" aria-controls="support-tunnel" aria-selected="false">Support Tunnel</a>
@@ -153,6 +153,8 @@
                   const textbox = document.getElementById("persist-input");
                   checkbox.checked = data.persist_logs;
                   textbox.value = data.auto_off_delay;
+
+                  return {"persist_logs": data.persist_logs, "auto_off_delay": data.auto_off_delay}
                 }
 
                 async function setPersist() {
@@ -190,7 +192,6 @@
                   }, 1500);
                 }
 
-                window.onload = getPersist;
               </script>
 
               <div id="admin-settings-dialog">


### PR DESCRIPTION
### What does this change intend to accomplish?
Adds a function prior to firing the update script that checks if persist_logs is set to true, and if not sets it to true for three days

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
