### PR TITLE
One-handed mobile control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   * Update Airplay icon to modern variant
   * Add gradient to background to break up the solid color
   * Reformat Admin Settings portion of Admin Panel (previously known as the Updater)
+  * Move home screen, player page controls to bottom of screen on mobile
+  * Update CSS breakpoints to scale the player page better on the smallest of screens
+  * Reformat Player page volume controls to look more modern
+  * Add safeguards in an attempt to reduce volume slider misinputs
 
 ## 0.4.5
 * Web App

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -222,13 +222,14 @@ Page.propTypes = {
 
 const App = ({ selectedPage }) => {
     return (
-        <div className="app">
+            <div className="app">
             <DisconnectedIcon />
-            <div className="app-body">
-                <Page selectedPage={selectedPage} />
+            <div className="background-gradient"></div>  {/* Used to make sure the background doesn't stretch or stop prematurely on scrollable pages */}
+                <div className="app-body">
+                    <Page selectedPage={selectedPage} />
+                </div>
+                <MenuBar pageNumber={selectedPage} />
             </div>
-            <MenuBar pageNumber={selectedPage} />
-        </div>
     );
 };
 App.propTypes = {

--- a/web/src/App.scss
+++ b/web/src/App.scss
@@ -1,10 +1,16 @@
 @use "src/general";
 
+.background-gradient {
+  background: general.$bg-gradient;
+  position: fixed;
+  z-index: -1;
+  height: 100vh;
+  width: 100vw;
+}
+
 .app {
   // display: flex;
   // width: 100vw;
-  height: 100vh;  // Required to not have weird paneling with gradient backgrounds
-  background: general.$bg-gradient;
   // padding-top: 0.6rem;
   // padding-bottom: 0.6rem;
   // padding: 0.6rem;
@@ -23,4 +29,39 @@
 
 .app-body {
   padding-bottom: general.$navbar-height;
+}
+
+@media (general.$is-landscape){
+  // Themed scrollbar is overridden by 90% of mobile apps and browsers, but only partially overridden by one (andorid app)
+  // This still looks better on desktop, so gate it to only being on desktop without running the risk for the weird android app situation
+
+  .pill-scrollbar {
+    max-height: inherit;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.5) transparent;
+  }
+
+  .pill-scrollbar::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+  }
+
+  .pill-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .pill-scrollbar::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 999px;
+    border: 3px solid rgba(255, 255, 255, 0.5);
+    @supports (-webkit-overflow-scrolling: touch) {
+      border: none;
+    }
+  }
+
+  .pill-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(0, 0, 0, 0.7);
+  }
+
 }

--- a/web/src/components/Card/Card.jsx
+++ b/web/src/components/Card/Card.jsx
@@ -13,8 +13,10 @@ const Card = ({
     selected,
     selectable,
     onClick,
+
+    secondary,
 }) => {
-    const cName = `card ${className} ${selectable && !selected ? "selectable" : ""} ${selected ? "selected" : ""}`
+    const cName = `card ${className} ${selectable && !selected ? "selectable" : ""} ${selected ? "selected" : ""} ${secondary ? "secondary" : "primary"}`
     const onClickFun = onClick === null ? () => {} : onClick;
     const topTransparency = selected ? 0.25 : 0.4;
     const bottomTransparency = selected ? 0.25 : 0.9;
@@ -49,6 +51,8 @@ Card.propTypes = {
     selected: PropTypes.bool,
     selectable: PropTypes.bool,
     onClick: PropTypes.func,
+
+    secondary: PropTypes.bool,
 };
 
 Card.defaultProps = {
@@ -56,7 +60,9 @@ Card.defaultProps = {
     className: "",
     selected: false,
     selectable: false,
-    onClick: null
+    onClick: null,
+
+    secondary: false,
 };
 
 export default Card;

--- a/web/src/components/Card/Card.scss
+++ b/web/src/components/Card/Card.scss
@@ -2,10 +2,16 @@
 
 .card {
   @include general.low-shadow;
-  background-color: general.$primary;
   border-radius: 18px;
 
   color: general.$text-color;
+}
+
+.primary {
+  background-color: general.$primary
+}
+.secondary {
+  background-color: general.$secondary
 }
 
 .selected {

--- a/web/src/components/CustomMarquee/CustomMarquee.jsx
+++ b/web/src/components/CustomMarquee/CustomMarquee.jsx
@@ -42,14 +42,13 @@ export default function CustomMarquee(props) {
         }
     }
 
-    let resizeTimout;
+    let resizeTimeout;  // Your IDE will say this is unused, it's actually used to make sure the timeout below is limited to one instance at a time by taking up a specific variable
     function handleResize(){
         if(!resizeCooldown.current){
             resizeCooldown.current = true;
 
             assessMarquee()
-
-            resizeTimout = setTimeout(()=>{resizeCooldown.current = false;}, 1000) // set a cooldown for resize checks to avoid excessive renders
+            resizeTimeout = setTimeout(()=>{resizeCooldown.current = false;}, 1000)
         }
     }
     window.addEventListener("resize", handleResize()); // Doesn't call assessMarquee directly to avoid calling thousands of times per second when resizing window

--- a/web/src/components/GroupVolumeSlider/GroupVolumeSlider.scss
+++ b/web/src/components/GroupVolumeSlider/GroupVolumeSlider.scss
@@ -23,5 +23,4 @@
 
 .group-volume-slider {
   width: 100%;
-  margin: 0 1rem;
 }

--- a/web/src/components/MediaControl/MediaControl.scss
+++ b/web/src/components/MediaControl/MediaControl.scss
@@ -8,7 +8,6 @@
   justify-content: center;
   margin-top: 1rem;
   margin-bottom: 1rem;
-  width: 90vw;
 }
 
 .media-inner {
@@ -19,23 +18,24 @@
 }
 
 .media-control {
+  font-size: 3.5rem;
   color: general.$controls-color;
   padding-left: 1.5rem;
   padding-right: 1.5rem;
 
 
-  @media (max-width: 365px) {
-    font-size: 1.5rem;
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
+  @media (general.$is-portrait) {
+    font-size: 3.5rem;
   }
 
-  @media (min-width: 365px) and (max-width: 425px) {
+  @media (max-width: general.$medium-mobile) {
     font-size: 2.5rem;
   }
 
-  @media (min-width: 425px) {
-    font-size: 3.5rem;
+  @media (max-width: general.$small-mobile) {
+    font-size: 1.5rem;
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
   }
 }
 

--- a/web/src/components/ModalCard/ModalCard.scss
+++ b/web/src/components/ModalCard/ModalCard.scss
@@ -47,33 +47,3 @@
 .modal-footer-button {
   @include general.button-hover;
 }
-
-
-.pill-scrollbar {
-  max-height: inherit;
-  overflow-y: auto;
-}
-
-.pill-scrollbar::-webkit-scrollbar {
-  width: 12px;
-  height: 12px;
-}
-
-.pill-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.pill-scrollbar::-webkit-scrollbar-thumb {
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 999px;
-  border: 3px solid rgba(255, 255, 255, 0.5);
-}
-
-.pill-scrollbar::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(0, 0, 0, 0.7);
-}
-
-.pill-scrollbar {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.5) transparent;
-}

--- a/web/src/components/SongInfo/SongInfo.scss
+++ b/web/src/components/SongInfo/SongInfo.scss
@@ -10,6 +10,12 @@
 
   white-space: nowrap;
   overflow: hidden;
+
+  // Used to ensure the smallest screens still have room for all metadata and controls on one screen without scrolling
+  @media (max-width: general.$medium-mobile){
+    max-height: 50vh;
+    max-width: 50vh;
+  }
 }
 
 .artist-name {

--- a/web/src/components/StreamBar/StreamBar.scss
+++ b/web/src/components/StreamBar/StreamBar.scss
@@ -12,6 +12,7 @@
     max-width: 22rem; // The same width as the album art, until the album art starts to shrink at 375px wide
   }
   @media (max-width: 375px) {
+    max-height: 7.5vh;
     max-width: 85vw;
   }
 }
@@ -21,15 +22,26 @@
   color: general.$text-color;
   width: 100%;
   max-width: 80%; // Leave space for icon
-  font-size: 2.5rem;
   font-weight: medium;
   white-space: nowrap;
   overflow: hidden;
   @include general.header-font;
   padding: 0.5rem;
+  @media (max-height: 500px){
+    font-size: 1.5rem;
+  }
+  @media (min-height: 500px){
+    font-size: 2.5rem;
+  }
 }
 
 .stream-bar-icon {
-  width: 4rem;
-  height: 4rem;
+  @media (max-height: 500px){
+    width: 2rem;
+    height: 2rem;
+  }
+  @media (min-height: 500px){
+    width: 4rem;
+    height: 4rem;
+  }
 }

--- a/web/src/components/VolumeSlider/VolumeSlider.jsx
+++ b/web/src/components/VolumeSlider/VolumeSlider.jsx
@@ -34,6 +34,32 @@ VolIcon.propTypes = {
 
 // generic volume slider used by other volume sliders
 const VolumeSlider = ({ vol, mute, setVol, setMute, disabled }) => {
+    const touchStartX = React.useRef(0);
+    const touchStartY = React.useRef(0);
+    const isScrolling = React.useRef(false);
+
+    const handleTouchStart = (e) => {
+        const touch = e.touches[0];
+        touchStartX.current = touch.clientX;
+        touchStartY.current = touch.clientY;
+        isScrolling.current = false;
+    };
+
+    const handleTouchMove = (e) => {
+        const touch = e.touches[0];
+        const diffX = touch.clientX - touchStartX.current;
+        const diffY = touch.clientY - touchStartY.current;
+
+        // Detect vertical drag, allow user to continue dragging within safe boundaries without needing to re-drag the slider
+        isScrolling.current = (Math.abs(diffY) / Math.abs(diffX)) > 1.65;  // Equivalent to approximately 60 deg
+    };
+
+    const handleVolChange = (val, force = false) => {
+        if (!isScrolling.current) {
+            setVol(val, force);
+        }
+    }
+
     return (
         <StopProp>
             <div className="volume-slider-container">
@@ -45,29 +71,31 @@ const VolumeSlider = ({ vol, mute, setVol, setMute, disabled }) => {
                 >
                     <VolIcon vol={vol} mute={mute} />
                 </div>
-                <Slider
-                    disabled={disabled}
-                    className="volume-slider"
-                    min={0}
-                    step={0.01}
-                    max={1}
-                    value={vol}
-                    // https://github.com/mui/material-ui/issues/32737#issuecomment-2060439608
-                    // ios does some weird emulation of mouse events from touch events, ignore those
-                    onChange={(e, val) => {
-                        if(isIOS() && e.type === "mousedown"){
-                            return;
-                        }
-                        setVol(val);
-                    }}
-                    onChangeCommitted={(e, val) => {
-                        if(isIOS() && e.type === "mouseup"){
-                            return;
-                        }
-                        setVol(val, true);
-                    }}
-                />
-            </div>
+                    <Slider
+                        disabled={disabled}
+                        className="volume-slider"
+                        min={0}
+                        step={0.01}
+                        max={1}
+                        value={vol}
+                        onTouchStart={handleTouchStart}
+                        onTouchMove={handleTouchMove}
+                        // https://github.com/mui/material-ui/issues/32737#issuecomment-2060439608
+                        // ios does some weird emulation of mouse events from touch events, ignore those
+                        onChange={(e, val) => {
+                            if (isIOS() && e.type === "mousedown") {
+                                return;
+                            }
+                            handleVolChange(val);
+                        }}
+                        onChangeCommitted={(e, val) => {
+                            if (isIOS() && e.type === "mouseup") {
+                                return;
+                            }
+                            handleVolChange(val, true);
+                        }}
+                    />
+                </div>
         </StopProp>
     );
 };

--- a/web/src/components/VolumeZones/VolumeZones.jsx
+++ b/web/src/components/VolumeZones/VolumeZones.jsx
@@ -6,12 +6,13 @@ import Card from "../Card/Card";
 
 import PropTypes from "prop-types";
 
-const VolumeZones = ({ sourceId, open, zones, groups, groupsLeft }) => {
+const VolumeZones = ({ sourceId, open, zones, groups, groupsLeft, alone }) => {
     const groupVolumeSliders = [];
     for (const group of groups) {
         groupVolumeSliders.push(
-            <Card className="group-vol-card" key={group.id}>
+            <Card secondary={!alone} className={`group-vol-card ${!alone ? "vol-margin" : ""}`} key={group.id}>
                 <GroupVolumeSlider
+                    alone={alone}
                     groupId={group.id}
                     sourceId={sourceId}
                     groupsLeft={groupsLeft}
@@ -23,8 +24,8 @@ const VolumeZones = ({ sourceId, open, zones, groups, groupsLeft }) => {
     const zoneVolumeSliders = [];
     zones.forEach((zone) => {
         zoneVolumeSliders.push(
-            <Card className="zone-vol-card" key={zone.id}>
-                <ZoneVolumeSlider zoneId={zone.id} />
+            <Card secondary={!alone} className={`zone-vol-card ${!alone ? "vol-margin" : ""}`} key={zone.id}>
+                <ZoneVolumeSlider alone={alone} zoneId={zone.id} />
             </Card>
         );
     });
@@ -44,6 +45,10 @@ VolumeZones.propTypes = {
     zones: PropTypes.array.isRequired,
     groups: PropTypes.array.isRequired,
     groupsLeft: PropTypes.array.isRequired,
+    alone: PropTypes.bool,
 };
+VolumeZones.defaultProps = {
+    alone: false,
+}
 
 export default VolumeZones;

--- a/web/src/components/VolumeZones/VolumesZones.scss
+++ b/web/src/components/VolumeZones/VolumesZones.scss
@@ -6,13 +6,25 @@
 }
 
 .zone-vol-card {
-  margin-top: 1rem;
-  padding: 0.75rem;
+  @media (max-width: general.$small-mobile){
+    padding: 0.5rem;
+  }
+  @media (min-width: general.$small-mobile){
+    padding: 0.75rem;
+  }
   color: general.$controls-color;
 }
 
 .group-vol-card {
-  margin-top: 1rem;
-  padding: 0.75rem;
+  @media (max-width: general.$small-mobile){
+    padding: 0.5rem;
+  }
+  @media (min-width: general.$small-mobile){
+    padding: 0.75rem;
+  }
   color: general.$controls-color;
+}
+
+.vol-margin {
+  margin-bottom: 1rem;
 }

--- a/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.jsx
+++ b/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.jsx
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 let sendingRequestCount = 0;
 
 // Volume slider for individual zone in volume drawer
-const ZoneVolumeSlider = ({ zoneId }) => {
+const ZoneVolumeSlider = ({ zoneId, alone }) => {
     const zoneName = useStatusStore((s) => s.status.zones[zoneId].name);
     const volume = useStatusStore((s) => s.status.zones[zoneId].vol_f);
     const mute = useStatusStore((s) => s.status.zones[zoneId].mute);
@@ -46,7 +46,7 @@ const ZoneVolumeSlider = ({ zoneId }) => {
     };
 
     return (
-        <div className="zone-volume-container">
+        <div className={`zone-volume-container ${alone ? "alone" : "grouped"}`}>
             {zoneName}
             <VolumeSlider
                 mute={mute}
@@ -59,6 +59,10 @@ const ZoneVolumeSlider = ({ zoneId }) => {
 };
 ZoneVolumeSlider.propTypes = {
     zoneId: PropTypes.number.isRequired,
+    alone: PropTypes.bool,
 };
+ZoneVolumeSlider.defaultProps = {
+    alone: false,
+}
 
 export default ZoneVolumeSlider;

--- a/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.scss
+++ b/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.scss
@@ -4,3 +4,12 @@
   @include general.header-font;
   font-size: 1rem;
 }
+
+.alone {
+  padding-right: 8px;
+}
+
+.grouped {
+  // 47px is the width of the dropdown icon + padding, this causes the child volume sliders to end in the same spot as the parent
+  padding-right: 47px;
+}

--- a/web/src/general.scss
+++ b/web/src/general.scss
@@ -23,6 +23,13 @@ $page-header-height: 3rem;
 // This number is the natural height of the navbar when an explicit height is not provided, and was not set to 56px arbitrarily
 $navbar-height: 56px;
 
+$small-mobile: 365px;
+$medium-mobile: 435px;
+
+// meant to be used directly in @media queries, like @media (general.$is-portrait){stuff}
+$is-portrait: "max-aspect-ratio: 1/1"; // equivalent to `if 100vh > 100vw`
+$is-landscape: "min-aspect-ratio: 1/1"; // equivalent to `if 100vw >= 100vh`
+
 // fonts
 @font-face {
   font-family: 'Open Sans';

--- a/web/src/pages/Home/Home.jsx
+++ b/web/src/pages/Home/Home.jsx
@@ -55,11 +55,13 @@ const PresetAndAdd = ({
         );
     } else {
         return (
-            <div
-                className="home-presets-button"
-                onClick={() => setPresetsModalOpen(true)}
-            >
-        Presets
+            <div className="home-presets-container">
+                <div
+                    className="home-presets-button"
+                    onClick={() => setPresetsModalOpen(true)}
+                >
+            Presets
+                </div>
             </div>
         );
     }

--- a/web/src/pages/Home/Home.scss
+++ b/web/src/pages/Home/Home.scss
@@ -2,7 +2,12 @@
 
 .home-outer {
   padding-top: 10px;
-  padding-bottom: 10px;
+  @media (general.$is-landscape) {
+    padding-bottom: 10px;
+  }
+  @media (general.$is-portrait) {
+    padding-bottom: 85px;  // Used to ensure the screen is still scrollable to just above the PresetAndAdd component on mobile
+  }
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -69,6 +74,12 @@
 }
 
 .home-presets-container {
+  @media (general.$is-portrait) {
+    position: fixed;
+    bottom: calc(general.$navbar-height + 10px);
+  }
+
+  z-index: 1; // Needed to ensure that scrolling marquees do not appear on top of the presets button
   display: flex;
 
   flex-direction: row;

--- a/web/src/pages/Player/Player.jsx
+++ b/web/src/pages/Player/Player.jsx
@@ -64,6 +64,19 @@ const Player = () => {
 
     selectActiveSource();
 
+    function DropdownArrow() {
+        // If on mobile, inital dropdown is at the bottom of the screen and expands upwards so the arrow should point up
+        // If on desktop, initial dropdown is in the middle of the screen and expands downwards so the arrow should point down
+        const isMobile = window.matchMedia("(max-width: 435px)").matches;
+        const Icon = isMobile ? (expanded ? KeyboardArrowDownIcon : KeyboardArrowUpIcon) : (expanded ? KeyboardArrowUpIcon : KeyboardArrowDownIcon);
+        return(
+            <Icon
+                className="player-volume-expand-button"
+                style={{ width: "3rem", height: "3rem" }}
+            />
+        )
+    }
+
     return (
         <div className="player-outer">
             {streamsModalOpen && (
@@ -87,6 +100,7 @@ const Player = () => {
                 </Grid>
                 <Grid item xs={2} sm={4} md={4} style={{maxWidth: "22rem"}}>
                     <Box
+                        className="album-art-container"
                         sx={{
                           display: 'flex',
                           justifyContent: 'center',
@@ -97,37 +111,31 @@ const Player = () => {
                     </Box>
                     <SongInfo sourceId={selectedSourceId} />
                 </Grid>
-                <Grid item xs={2} sm={4} md={4}>
-                    <MediaControl selectedSource={selectedSourceId} />
-                </Grid>
             </Grid>
-            {/* There are many sub-divs classed player-inner here because formatting was strange otherwise */}
-            <div className="player-inner">
-            </div>
-            <div className="player-inner">
-            </div>
-            <div className="player-inner">
-            </div>
 
-            {!alone && !is_streamer && zones.length > 0 && (
-                <Card className="player-volume-slider">
-                    <CardVolumeSlider sourceId={selectedSourceId} />
-                    <IconButton onClick={() => setExpanded(!expanded)}>
-                        {expanded ? (
-                            <KeyboardArrowUpIcon
-                                className="player-volume-expand-button"
-                                style={{ width: "3rem", height: "3rem" }}
-                            />
-                        ) : (
-                            <KeyboardArrowDownIcon
-                                className="player-volume-expand-button"
-                                style={{ width: "3rem", height: "3rem" }}
-                            />
-                        )}
-                    </IconButton>
-                </Card>
-            )}
-            <VolumeZones open={(expanded || alone)} sourceId={selectedSourceId} zones={zonesLeft} groups={usedGroups} groupsLeft={groupsLeft} />
+            <div className={alone ? "solo-media-controls" : "grouped-media-controls" } >
+                <MediaControl selectedSource={selectedSourceId} />
+            </div>
+            { (!is_streamer && zones.length > 0) ? (
+                (alone) ? (
+                    <div className="player-volume-container" >
+                        <VolumeZones alone open sourceId={selectedSourceId} zones={zonesLeft} groups={usedGroups} groupsLeft={groupsLeft} />
+                    </div>
+                ) : (
+                    <Card className="player-volume-container">
+                        <div className="player-volume-header">
+                            <CardVolumeSlider sourceId={selectedSourceId} />
+                            <IconButton onClick={() => setExpanded(!expanded)}>
+                                <DropdownArrow />
+                            </IconButton>
+                        </div>
+
+                        <div className={`player-volume-body pill-scrollbar ${expanded ? "expanded-volume-body" : ""}`}>
+                            <VolumeZones open={(expanded)} sourceId={selectedSourceId} zones={zonesLeft} groups={usedGroups} groupsLeft={groupsLeft} />
+                        </div>
+                    </Card>
+                )
+            ) : null }
         </div>
     );
 };

--- a/web/src/pages/Player/Player.scss
+++ b/web/src/pages/Player/Player.scss
@@ -28,17 +28,70 @@
 
 .player-album-art {
   align-self: center;
-  max-width: 95vw;
   max-height: 22rem;
   border-radius: 2.5%;
+  @media (general.$is-portrait) {
+    max-width: 85vw;
+  }
+  @media (max-width: general.$small-mobile) {
+    max-width: 50vw;
+  }
 }
 
-.player-volume-slider {
+// Solo vs Grouped media controls are different because solo volumes have titles, making them tall enough to need further adjustment
+.grouped-media-controls {
+  @media (general.$is-portrait) {
+    position: fixed;
+    z-index: 0;
+    bottom: 130px
+  }
+}
+.solo-media-controls {
+  @media (general.$is-portrait) {
+    position: fixed;
+    z-index: 0;
+    bottom: 150px;
+  }
+}
+
+.player-volume-container {
+  @media (general.$is-portrait) {
+    position: fixed;
+    bottom: calc(general.$navbar-height + 7px);
+    z-index: 1;
+  }
+}
+
+.solo-volume {
+  @media (general.$is-portrait) {
+    position: fixed;
+    bottom: calc(general.$navbar-height + 7px);
+    z-index: 1;
+  }
+}
+
+.player-volume-header {
   display: flex;
   flex-direction: row;
   align-items: center;
   color: general.$controls-color;
   width: 90vw;
+}
+
+.player-volume-body {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  @media (general.$is-portrait) {
+    max-height: calc(85vh - 120px);
+    overflow-y: auto;
+  }
+}
+
+.expanded-volume-body {
+  @media (general.$is-portrait) {
+    height: 100vh;
+  }
 }
 
 .player-volume-expand-button {


### PR DESCRIPTION
### What does this change intend to accomplish?
Move song controls, preset and add buttons to bottom of the screen on mobile

Adjust player page volume dropdown to more visibly include the underlying components, and limit height to make them scrollable without needing to scroll the whole page

Add many CSS breakpoints to ensure elements continue to work on the smallest screens

Home Page:
Before:
![image](https://github.com/user-attachments/assets/8597524e-d31a-4638-a805-06781b16f7b7)

After:
![image](https://github.com/user-attachments/assets/61acc008-6da6-4ef6-9a57-b54b3ef95670)


Player Page:
Before:
![image](https://github.com/user-attachments/assets/aa875d99-e192-484c-94dc-a573d3a807c3)
![image](https://github.com/user-attachments/assets/9988bb87-0df9-4ac1-9255-373c0155a871)

After:
![image](https://github.com/user-attachments/assets/30c307dd-fed5-48ab-a033-086ae159bc83)
![image](https://github.com/user-attachments/assets/c0a01fd0-3a85-4616-ac33-334574f66944)


### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
