### PR TITLE
Fix issue causing status bar to block app controls

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -224,7 +224,7 @@ const App = ({ selectedPage }) => {
     return (
         <div className="app">
             <DisconnectedIcon />
-            <div style={{ paddingBottom: "56px" }}>
+            <div className="app-body">
                 <Page selectedPage={selectedPage} />
             </div>
             <MenuBar pageNumber={selectedPage} />

--- a/web/src/App.scss
+++ b/web/src/App.scss
@@ -20,3 +20,7 @@
   height: 100vh;
   background-color: green;
 }
+
+.app-body {
+  padding-bottom: general.$navbar-height;
+}

--- a/web/src/components/MenuBar/MenuBar.scss
+++ b/web/src/components/MenuBar/MenuBar.scss
@@ -5,5 +5,6 @@
   z-index: 1; // The Marquees on player cards appeared above the MenuBar otherwise, the MenuBar needs to be on top of everything always
   bottom: 0;
   width: 100vw;
+  height: general.$navbar-height;
   @include general.low-shadow-up;
 }

--- a/web/src/components/StatusBars/StatusBar.jsx
+++ b/web/src/components/StatusBars/StatusBar.jsx
@@ -15,6 +15,7 @@ export default function StatusBar(props) {
 
     return(
         <Snackbar
+            className="snackbar"
             autoHideDuration={3000}
             anchorOrigin={{vertical: "bottom", horizontal: "left"}}
             open={open}

--- a/web/src/components/StatusBars/StatusBars.scss
+++ b/web/src/components/StatusBars/StatusBars.scss
@@ -30,3 +30,7 @@
   --right: translate(5px, 0px);
   animation: errorShake 0.5s 1; // Only animate once, reapplying the class will reapply the animation
 }
+
+.snackbar {
+  bottom: calc(general.$navbar-height + 4px); // Used to keep the snackbar above the navbar at the bottom as to not block controls on mobile
+}

--- a/web/src/general.scss
+++ b/web/src/general.scss
@@ -19,6 +19,9 @@ $select-color-gray: #bdbdbd; // for preset used_last
 $mute-color: #dc3545;
 
 $page-header-height: 3rem;
+// Used to ensure that fixed-positioned components don't appear on top of the navbar
+// This number is the natural height of the navbar when an explicit height is not provided, and was not set to 56px arbitrarily
+$navbar-height: 56px;
 
 // fonts
 @font-face {


### PR DESCRIPTION
### What does this change intend to accomplish?
I found that our current StatusBar components would completely block all app controls on mobile, bump the bottom of the StatusBar up above the controls so you can now leave the problem screen

Before:
![image](https://github.com/user-attachments/assets/76337ae7-63f4-4dcc-8bf5-b120c22f9bf3)

After:
![image](https://github.com/user-attachments/assets/ac372e33-07d4-43a7-884d-8b5fefe4644a)


### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
