### PR TITLE
Add default streams for first startup

### DIFF
--- a/amplipi/defaults.py
+++ b/amplipi/defaults.py
@@ -19,10 +19,10 @@ USER_CONFIG_DIR = os.path.join(os.path.expanduser('~'), '.config', 'amplipi')
 DEFAULT_CONFIG = {  # This is the system state response that will come back from the amplipi box
   "version": 1,
   "sources": [  # this is an array of source objects, each has an id, name, type specifying whether source comes from a local (like RCA) or streaming input like pandora
-    {"id": 0, "name": "Input 1", "input": ""},
-    {"id": 1, "name": "Input 2", "input": ""},
-    {"id": 2, "name": "Input 3", "input": ""},
-    {"id": 3, "name": "Input 4", "input": ""},
+    {"id": 0, "name": "Output 1", "input": ""},
+    {"id": 1, "name": "Output 2", "input": ""},
+    {"id": 2, "name": "Output 3", "input": ""},
+    {"id": 3, "name": "Output 4", "input": ""},
   ],
   # NOTE: streams and groups seem like they should be stored as dictionaries with integer keys
   #       this does not make sense because JSON only allows string based keys
@@ -34,6 +34,10 @@ DEFAULT_CONFIG = {  # This is the system state response that will come back from
     {"id": RCAs[3], "name": "Input 4", "type": "rca", "index": 3, "browsable": False, "disabled": False},
     {"id": 1000, "name": "Groove Salad", "type": "internetradio", "url": "http://ice6.somafm.com/groovesalad-32-aac",
      "logo": "https://somafm.com/img3/groovesalad-400.jpg", "browsable": False, "disabled": False},
+    {"id": 1001, "name": "AmpliPro 1", "type": "spotify", "disabled": False, "browsable": False},
+    {"id": 1002, "name": "AmpliPro 2", "type": "spotify", "disabled": False, "browsable": False},
+    {"id": 1003, "name": "AmpliPro 1", "type": "airplay", "disabled": False, "ap2": False, "browsable": False},
+    {"id": 1004, "name": "AmpliPro 2", "type": "airplay", "disabled": False, "ap2": True, "browsable": False}
   ],
   "zones": [  # this is an array of zones, array length depends on # of boxes connected
     {"id": 0, "name": "Zone 1", "source_id": 0, "mute": True, "disabled": False,
@@ -79,6 +83,10 @@ STREAMER_CONFIG = {  # This is the system state response that will come back fro
     {"id": AUX_STREAM_ID, "name": "Aux", "type": "aux", "browsable": False, "disabled": False},
     {"id": 1000, "name": "Groove Salad", "type": "internetradio", "url": "http://ice6.somafm.com/groovesalad-32-aac",
      "logo": "https://somafm.com/img3/groovesalad-400.jpg", "browsable": False, "disabled": False},
+    {"id": 1001, "name": "AmpliPro 1", "type": "spotify", "disabled": False, "browsable": False},
+    {"id": 1002, "name": "AmpliPro 2", "type": "spotify", "disabled": False, "browsable": False},
+    {"id": 1003, "name": "AmpliPro 1", "type": "airplay", "disabled": False, "ap2": False, "browsable": False},
+    {"id": 1004, "name": "AmpliPro 2", "type": "airplay", "disabled": False, "ap2": True, "browsable": False}
   ],
   "zones": [  # this is an array of zones, array length depends on # of boxes connected
   ],

--- a/scripts/cleanup
+++ b/scripts/cleanup
@@ -106,6 +106,13 @@ until $(curl --output /dev/null --silent --fail http://amplipi.local); do
 done
 echo "" # newline
 
+# connecting default streams
+echo -e "\nConnecting Groove Salad, Spotify, Airplay sources"
+curl -X PATCH http://amplipi.local/api/sources/0 -H "Content-Type: application/json" -d '{"input": "stream=1000"}'
+curl -X PATCH http://amplipi.local/api/sources/1 -H "Content-Type: application/json" -d '{"input": "stream=1001"}'
+curl -X PATCH http://amplipi.local/api/sources/2 -H "Content-Type: application/json" -d '{"input": "stream=1004"}'
+curl -X PATCH http://amplipi.local/api/zones -H "Content-Type: application/json" -d '{"zones": [0, 1, 2, 3, 4, 5], "update": {"mute": true, "source_id": 0}}'
+
 # remove old known_hosts entries
 echo -e "\nCleaning old ~/.ssh/known_hosts entries on local machine"
 ssh-keygen -f ~/.ssh/known_hosts -R amplipi.local


### PR DESCRIPTION
Sets system default state to Groove Salad connected to all zones at 0 volume and muted everywhere, as well as Spotify and Airplay2 sources connected to no zones for first startup
Can be tested by going to Setttings -> Config -> Factory Reset

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
