### PR TITLE
Remove margin from PageHeader

### DIFF
--- a/web/src/components/PageHeader/PageHeader.scss
+++ b/web/src/components/PageHeader/PageHeader.scss
@@ -1,7 +1,6 @@
 @use "src/general.scss";
 
 .page-header {
-  margin: 0.5rem;
   font-size: 3rem;
   text-align: center;
   display: flex;


### PR DESCRIPTION
### What does this change intend to accomplish?
I noticed there was a thin black strip at the top of the screen on the About page, and found it was due to the `PageHeader` component having a `0.5 rem` `margin-top`

This PR fixes that

Before:
![image](https://github.com/user-attachments/assets/8f2af510-3588-4447-8269-9939199c9f0a)

After:
![image](https://github.com/user-attachments/assets/29e47e3d-d365-4e9e-9647-f14a58518960)


### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
