### PR TITLE
Set default value for onApply on Streams Modal

### DIFF
--- a/web/src/components/StreamsModal/StreamsModal.jsx
+++ b/web/src/components/StreamsModal/StreamsModal.jsx
@@ -150,11 +150,12 @@ const StreamsModal = ({
 };
 StreamsModal.propTypes = {
     sourceId: PropTypes.number.isRequired,
-    onApply: PropTypes.func.isRequired,
+    onApply: PropTypes.func,
     onClose: PropTypes.func.isRequired,
     applyImmediately: PropTypes.bool,
 };
 StreamsModal.defaultProps = {
+    onApply: () => {},
     applyImmediately: true,
 };
 


### PR DESCRIPTION
### What does this change intend to accomplish?
In #1015, I broke stream swapping and did not notice as I was only trying to touch stream creating. This PR makes it so that the modal closes again by not throwing errors due to the lack of onApply in most instances of that modal flow.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
