### PR TITLE
Stream Editing Fix

### DIFF
--- a/web/src/components/CreateStreamModal/StreamModal/StreamModal.jsx
+++ b/web/src/components/CreateStreamModal/StreamModal/StreamModal.jsx
@@ -198,7 +198,7 @@ const InternetRadioSearch = ({ onChange }) => {
 InternetRadioSearch.propTypes = {
     onChange: PropTypes.func.isRequired,
 };
-const StreamModal = ({ stream, onClose, del }) => {
+const StreamModal = ({ stream, onClose, apply, del }) => {
     const [streamFields, setStreamFields] = React.useState(
         JSON.parse(JSON.stringify(stream))
     ); // set streamFields to copy of stream
@@ -207,14 +207,6 @@ const StreamModal = ({ stream, onClose, del }) => {
     const [errorField, setErrorField] = React.useState("");
     const [hasError, setHasError] = React.useState(false); // Need a discrete hasError bool to trigger error
     const [renderAlertAnimation, setAlertAnimation] = React.useState(0); // Need a discrete hasError bool to trigger error
-
-    const apply = (stream) => {
-        return fetch("/api/stream", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(stream),
-        });
-    };
 
     const streamTemplate = StreamTemplates.filter(
         (t) => t.type === stream.type
@@ -243,8 +235,11 @@ const StreamModal = ({ stream, onClose, del }) => {
                     text={errorMessage}
                 />
             }
+
+            // del is only used during edit, so use that to define when the modal should be in edit mode
+            // Would use apply instead of del for the first one if apply didn't have a default as well
             buttons={[
-                [ "Create Stream", () => {
+                [ del ? "Edit Stream" : "Create Stream", () => {
                         // Check if all required fields are filled
                         for (const field of templateFields) {
                             if (field.required && (!(field.name.toLowerCase() in streamFields) || streamFields[field.name.toLowerCase()] === "")) {
@@ -396,7 +391,17 @@ const StreamModal = ({ stream, onClose, del }) => {
 StreamModal.propTypes = {
     stream: PropTypes.any.isRequired,
     onClose: PropTypes.func.isRequired,
+    apply: PropTypes.func,
     del: PropTypes.func,
 };
+StreamModal.defaultProps = {
+    apply: (stream) => {
+        return fetch("/api/stream", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(stream),
+        });
+    },
+}
 
 export default StreamModal;

--- a/web/src/components/ModalCard/ModalCard.jsx
+++ b/web/src/components/ModalCard/ModalCard.jsx
@@ -65,7 +65,7 @@ const ModalCard = ({
 ModalCard.propTypes = {
     header: PropTypes.string,
     children: PropTypes.any.isRequired,
-    footer: PropTypes.string,
+    footer: PropTypes.any,
     onClose: PropTypes.func.isRequired,
     buttons: PropTypes.array
 };

--- a/web/src/components/StatusBars/AlertBar.jsx
+++ b/web/src/components/StatusBars/AlertBar.jsx
@@ -45,7 +45,7 @@ AlertBar.propTypes = {
     status: PropTypes.bool.isRequired,
     text: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
-    renderAnimationState: PropTypes.int,
+    renderAnimationState: PropTypes.number,
 };
 AlertBar.defaultProps = {
     renderAnimationState: 1,


### PR DESCRIPTION
### What does this change intend to accomplish?
Fix stream editing workflow, no longer creates an edited clone of a stream

While working on #1026, I screwed up the editing workflow by not noticing how the apply function worked there, I've now corrected that

This update fixes an issue where hitting the confirm button on stream edit would just make an edited clone of the stream in the streams list rather than creating a new one, as well as solving two minor javascript in related files along the way

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
