### PR TITLE
Center preset edit modal title

### DIFF
--- a/web/src/pages/Settings/Presets/EditPresetModal/EditPresetModal.scss
+++ b/web/src/pages/Settings/Presets/EditPresetModal/EditPresetModal.scss
@@ -6,4 +6,5 @@
   font-size: 2rem;
   margin: 0.5rem;
   // padding: 0.5rem;
+  text-align: center;
 }


### PR DESCRIPTION
### What does this change intend to accomplish?
The edit preset modal was the only modal without a centered title

Before:
![image](https://github.com/user-attachments/assets/e93d24c5-8c2c-471c-bb44-4bd04e3b099c)

After:
![image](https://github.com/user-attachments/assets/f7151af4-2847-4445-bb2c-f4afb68b1448)


### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
