### PR TITLE
Disconnect zones from source when stream disconnects

### DIFF
--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -339,6 +339,12 @@ def set_source(update: models.SourceUpdate, ctrl: Api = Depends(get_ctrl), sid: 
     valid_update = update.copy()
     valid_update.input = f'stream={defaults.RCAs[sid]}'
     logging.warning(f'correcting deprecated use of RCA inputs from {update} to {valid_update}')
+  if update.input == 'None':
+    # Disconnect zones from inactive sources
+    zones = get_zones(ctrl=ctrl)
+    connected_zones = [zone.id for zone in zones["zones"] if zone.source_id == sid and zone.id is not None] # zone.id should never actually be none, but the linter worries about it
+    if connected_zones:
+      ctrl.set_zones(models.MultiZoneUpdate(zones=connected_zones, update=models.ZoneUpdate(source_id=-1)))
   return code_response(ctrl, ctrl.set_source(sid, update))
 
 

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -341,7 +341,7 @@ def set_source(update: models.SourceUpdate, ctrl: Api = Depends(get_ctrl), sid: 
     logging.warning(f'correcting deprecated use of RCA inputs from {update} to {valid_update}')
   if update.input == 'None':
     # Disconnect zones from inactive sources
-    zones = get_zones(ctrl=ctrl)
+    zones = ctrl.get_state().zones
     connected_zones = [zone.id for zone in zones["zones"] if zone.source_id == sid and zone.id is not None]  # zone.id should never actually be none, but the linter worries about it
     if connected_zones:
       ctrl.set_zones(models.MultiZoneUpdate(zones=connected_zones, update=models.ZoneUpdate(source_id=-1)))

--- a/amplipi/app.py
+++ b/amplipi/app.py
@@ -342,7 +342,7 @@ def set_source(update: models.SourceUpdate, ctrl: Api = Depends(get_ctrl), sid: 
   if update.input == 'None':
     # Disconnect zones from inactive sources
     zones = get_zones(ctrl=ctrl)
-    connected_zones = [zone.id for zone in zones["zones"] if zone.source_id == sid and zone.id is not None] # zone.id should never actually be none, but the linter worries about it
+    connected_zones = [zone.id for zone in zones["zones"] if zone.source_id == sid and zone.id is not None]  # zone.id should never actually be none, but the linter worries about it
     if connected_zones:
       ctrl.set_zones(models.MultiZoneUpdate(zones=connected_zones, update=models.ZoneUpdate(source_id=-1)))
   return code_response(ctrl, ctrl.set_source(sid, update))


### PR DESCRIPTION
### What does this change intend to accomplish?
Disconnects zones from source when stream disconnects from the same source. This is useful because leaving zones and groups secretly connected in the background had some potential conflicts with home assistant automations 

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] If applicable, have you updated the CHANGELOG?
* [ ] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [ ] Have you written new tests for your core features/changes, as applicable?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
