### PR TITLE
Update Readme.md supported streams chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Most of these digital streaming services are provided by other open-source proje
 |Internet Radio|Yes|Yes|Yes|[VLC](https://github.com/videolan/vlc)||
 |Plexamp|No|No|No|[Plexamp](https://plexamp.com/)|See [#200](http://github.com/micro-nova/AmpliPi/issues/200)|
 |FM Radio|Yes|No|Yes|[rtl-sdr](https://osmocom.org/projects/rtl-sdr/wiki/Rtl-sdr)/[redsea](https://github.com/windytan/redsea)|Requires [RTL SDR](https://www.rtl-sdr.com/buy-rtl-sdr-dvb-t-dongles/) compatible USB device|
-|LMS|Yes|Yes|No|[squeezelite](https://github.com/ralph-irving/squeezelite)|Requires separate LMS Server|
+|LMS|Yes|Yes|Yes|[squeezelite](https://github.com/ralph-irving/squeezelite)|Requires separate LMS Server or activation of LMS mode in the system settings|
 |Bluetooth|Yes|No|Yes|[bluezero](https://github.com/ukBaz/python-bluezero)|See [Bluetooth docs](docs/BLUETOOTH.md)|
 |Google Cast|No||||Need to investigate|
-|Offline Music|No||||See [#66](http://github.com/micro-nova/AmpliPi/issues/66)|
+|Offline Music|Yes|Yes|Yes|[VLC](https://github.com/videolan/vlc)|With USB media device, still requires local network connection to control system|
 |TIDAL|No||||See [#87](http://github.com/micro-nova/AmpliPi/issues/87)|
 
 In the future we plan to integrate with several home automation systems. Below is their current status.


### PR DESCRIPTION
### What does this change intend to accomplish?
We haven't been properly advertising our capabilities in the README, this PR edits the chart that shows what streams we support and to what degree to show that we do so for each by saying that we do support LMS metadata, that we offer an inbuilt LMS server, and that we support offline music via the file player stream