### PR TITLE
Player zone add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Upgraded volume calculations to preserve relative positions when hitting the min or max setting via source volume bar
   * Update our spotify provider `go-librespot` to `0.7.3`
   * Upgrade from Logitech Media Server 8.5.2 to Lyrion Music Server 9.0.3
+* Web App
+  * Added [  +  ] button to player page to allow selection of zones and groups from player page
 
 # 0.4.11
 * System

--- a/web/src/components/RectangularButton/RectangularButton.jsx
+++ b/web/src/components/RectangularButton/RectangularButton.jsx
@@ -11,7 +11,7 @@ export default function RectangularButton({onClick, large, label}){
         >
             {label}
         </div>
-    )
+    );
 }
 RectangularButton.propTypes = {
     onClick: PropTypes.func.isRequired,
@@ -20,4 +20,4 @@ RectangularButton.propTypes = {
 };
 RectangularButton.defaultProps = {
     large: false,
-}
+};

--- a/web/src/components/RectangularButton/RectangularButton.scss
+++ b/web/src/components/RectangularButton/RectangularButton.scss
@@ -1,7 +1,7 @@
 @use "src/general";
 
 .rectangular-button {
-  // @include general.low-shadow;
+  @include general.low-shadow;
   @include general.regular-font;
   width: 100%;
   height: 4rem;

--- a/web/src/components/VolumeZones/VolumeZones.jsx
+++ b/web/src/components/VolumeZones/VolumeZones.jsx
@@ -3,16 +3,16 @@ import "./VolumesZones.scss";
 import ZoneVolumeSlider from "../ZoneVolumeSlider/ZoneVolumeSlider";
 import GroupVolumeSlider from "../GroupVolumeSlider/GroupVolumeSlider";
 import Card from "../Card/Card";
+import RectangularButton from "@/components/RectangularButton/RectangularButton";
 
 import PropTypes from "prop-types";
 
-const VolumeZones = ({ sourceId, open, zones, groups, groupsLeft, alone }) => {
+const VolumeZones = ({ sourceId, open, zones, groups, groupsLeft, setZonesModalOpen }) => {
     const groupVolumeSliders = [];
     for (const group of groups) {
         groupVolumeSliders.push(
-            <Card secondary={!alone} className={`group-vol-card ${!alone ? "vol-margin" : ""}`} key={group.id}>
+            <Card secondary className="group-vol-card vol-margin" key={group.id}>
                 <GroupVolumeSlider
-                    alone={alone}
                     groupId={group.id}
                     sourceId={sourceId}
                     groupsLeft={groupsLeft}
@@ -24,17 +24,26 @@ const VolumeZones = ({ sourceId, open, zones, groups, groupsLeft, alone }) => {
     const zoneVolumeSliders = [];
     zones.forEach((zone) => {
         zoneVolumeSliders.push(
-            <Card secondary={!alone} className={`zone-vol-card ${!alone ? "vol-margin" : ""}`} key={zone.id}>
-                <ZoneVolumeSlider alone={alone} zoneId={zone.id} />
+            <Card secondary className="zone-vol-card vol-margin" key={zone.id}>
+                <ZoneVolumeSlider zoneId={zone.id} />
             </Card>
         );
     });
 
-    if(open){
+    const noZones = zoneVolumeSliders.length == 0 && groupVolumeSliders.length == 0;
+
+    if (open) {
         return (
-            <div className="volume-sliders-container">
+            <div className={`volume-sliders-container ${(!noZones) && "add-padding"}`}>
                 {groupVolumeSliders}
                 {zoneVolumeSliders}
+                <RectangularButton large label="+" onClick={() => {setZonesModalOpen(true);}} />
+            </div>
+        );
+    } else if (noZones){
+        return(
+            <div className="volume-sliders-container">
+                <RectangularButton large label="+" onClick={() => {setZonesModalOpen(true);}} />
             </div>
         );
     }
@@ -45,10 +54,7 @@ VolumeZones.propTypes = {
     zones: PropTypes.array.isRequired,
     groups: PropTypes.array.isRequired,
     groupsLeft: PropTypes.array.isRequired,
-    alone: PropTypes.bool,
+    setZonesModalOpen: PropTypes.func.isRequired,
 };
-VolumeZones.defaultProps = {
-    alone: false,
-}
 
 export default VolumeZones;

--- a/web/src/components/VolumeZones/VolumesZones.scss
+++ b/web/src/components/VolumeZones/VolumesZones.scss
@@ -5,6 +5,10 @@
   color: general.$controls-color;
 }
 
+.add-padding {
+  padding-bottom: 1rem;
+}
+
 .zone-vol-card {
   @media (max-width: general.$small-mobile){
     padding: 0.5rem;

--- a/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.jsx
+++ b/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.jsx
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 let sendingRequestCount = 0;
 
 // Volume slider for individual zone in volume drawer
-const ZoneVolumeSlider = ({ zoneId, alone }) => {
+const ZoneVolumeSlider = ({ zoneId }) => {
     const setSystemState = useStatusStore((s) => s.setSystemState);
     const zoneName = useStatusStore((s) => s.status.zones[zoneId].name);
     const volume = useStatusStore((s) => s.status.zones[zoneId].vol_f);
@@ -49,7 +49,7 @@ const ZoneVolumeSlider = ({ zoneId, alone }) => {
     };
 
     return (
-        <div className={`zone-volume-container ${alone ? "alone" : "grouped"}`}>
+        <div className="zone-volume-container grouped">
             {zoneName}
             <VolumeSlider
                 mute={mute}
@@ -62,10 +62,6 @@ const ZoneVolumeSlider = ({ zoneId, alone }) => {
 };
 ZoneVolumeSlider.propTypes = {
     zoneId: PropTypes.number.isRequired,
-    alone: PropTypes.bool,
 };
-ZoneVolumeSlider.defaultProps = {
-    alone: false,
-}
 
 export default ZoneVolumeSlider;

--- a/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.scss
+++ b/web/src/components/ZoneVolumeSlider/ZoneVolumeSlider.scss
@@ -5,10 +5,6 @@
   font-size: 1rem;
 }
 
-.alone {
-  padding-right: 8px;
-}
-
 .grouped {
   // 47px is the width of the dropdown icon + padding, this causes the child volume sliders to end in the same spot as the parent
   padding-right: 47px;

--- a/web/src/pages/Player/Player.scss
+++ b/web/src/pages/Player/Player.scss
@@ -84,6 +84,11 @@
   flex-direction: column;
   @media (general.$is-portrait) {
     max-height: calc(85vh - 120px);
+  }
+}
+
+.scrollable{ // Was part of .player-volume-body until it started adding scrollbars when only the [  +  ] was in that div
+  @media (general.$is-portrait) {
     overflow-y: auto;
   }
 }


### PR DESCRIPTION
### What does this change intend to accomplish?
Add the ability to change zones and groups from the player page using new button

Closes #1080 and #1076, potentially removes need for #1079 thanks to the relativistic volume bar always being there now.

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`
* [x] If this is a UI change, have you tested it across multiple browser platforms on both desktop and mobile?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Desktop:

* No Zones/Groups <img width="1726" height="761" alt="image" src="https://github.com/user-attachments/assets/3267f517-e3ac-4142-85f0-0dcb97d93464" />
* One Zone <img width="1780" height="838" alt="image" src="https://github.com/user-attachments/assets/dfbc999b-581d-48d7-9af3-cc556c1c3a30" />


### Mobile:
* No Zones/Groups <img width="396" height="853" alt="image" src="https://github.com/user-attachments/assets/a79fbcbe-edb0-46a6-9827-98a5d4eb4cb5" />
* One Zone <img width="396" height="853" alt="image" src="https://github.com/user-attachments/assets/a234b297-b5f3-4654-bfd5-e58b86825846" />


