### PR TITLE
Deactivate frontend caching via the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Future Release
 
+* Web App
+  * Changed caching rules to ensure that users don't get stuck with old versions of the webapp post update
+
 
 ## 0.4.10
 


### PR DESCRIPTION
### What does this change intend to accomplish?
Deactivates caching of the frontend css and javascript files to avoid users being stuck with stale code, particularly fetch requests that no longer match backend endpoints

Will require users to clear cache one time post release but never again afterwards

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
