### PR TITLE
Bump go-librespot to version 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # AmpliPi Software Releases
 
 # Future Release
-
+* System
+  * Update our spotify provider `go-librespot` to `0.7.1`
 * Web App
   * Changed caching rules to ensure that users don't get stuck with old versions of the webapp post update
 

--- a/bin/arm/go-librespot
+++ b/bin/arm/go-librespot
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a5b6c27af2700faea87ea4ef7976032279e9f1d07aa898ccd5d3e592ae9c1f1
-size 15477612
+oid sha256:0f942a7493110eec2c3427746db2a3bb6ddf82df53b82df2278ce4500f42c406
+size 16616084

--- a/bin/x64/go-librespot
+++ b/bin/x64/go-librespot
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:595ff1a9099c2d5c98848beb9a1d83711c664360e727f0a2f6db89ae45846a7e
-size 16235664
+oid sha256:888f145ad65820b94cdc2cfd518707989213a8f8d14ee057de20e5e4a6eb8dbf
+size 17333032


### PR DESCRIPTION
### What does this change intend to accomplish?
A simple golibrespot version bump. I don't think this will solve the ongoing spotify issues if the issue is what we've thought it is thus far (https://amplipi.discourse.group/t/spotify-not-connecting/403/4?u=amplipi) but it never hurts to bump, either; especially when there's been 2 major bumps since our last upgrade

### Checklist

* [x] Have you tested your changes and ensured they work?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [x] Does your submission pass linting & tests? You can test on localhost using `./scripts/test`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
