### PR TITLE
Replace github sponsor link to be our online store

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: https://www.kickstarter.com/projects/micro-nova/amplipi-home-audio-system # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: https://www.amplipro.com/shop # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
### What does this change intend to accomplish?
I noticed our sponsor link goes to our long-defunct kickstarter, I've replaced the link with a place people can actually give us money if they so choose.
