### PR TITLE
Run LMS stream processes in their own process group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Added in-place preamp recovery when I2C writes fail persistently
   * Fixed all loopback dmix devices sharing one ipc_key in asound.conf, which made loopback playback devices intermittently fail to open with EINVAL (#957)
   * Disabled USB autosuspend for the CM6206 USB audio device
+  * Fixed LMS stream shutdown force-killing the wrong process group
 * Web App
   * Add warning for older versions of the webapp running on newer backends
 

--- a/amplipi/streams/lms.py
+++ b/amplipi/streams/lms.py
@@ -90,9 +90,9 @@ class LMS(PersistentStream):
         meta_args.extend(["--server", f"{self.server}"])
       if self.port is not None:
         meta_args.extend(["--port", f"{self.port}"])
-      self.meta_proc = subprocess.Popen(args=meta_args, stdout=sys.stdout, stderr=sys.stderr)
+      self.meta_proc = subprocess.Popen(args=meta_args, stdout=sys.stdout, stderr=sys.stderr, preexec_fn=os.setpgrp)
 
-      self.proc = subprocess.Popen(args=lms_args)
+      self.proc = subprocess.Popen(args=lms_args, preexec_fn=os.setpgrp)
     except Exception as exc:
       logger.exception(f'error starting lms: {exc}')
 
@@ -106,7 +106,10 @@ class LMS(PersistentStream):
       except Exception as e:
         logger.exception(f"failed to gracefully terminate LMS stream {self.name}: {e}")
         logger.warning(f"forcefully killing LMS stream {self.name}")
-        os.killpg(self.proc.pid, signal.SIGKILL)
+        try:
+          os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+          pass
         self.proc.communicate(timeout=3)
 
     if self.meta_proc is not None:
@@ -116,7 +119,10 @@ class LMS(PersistentStream):
       except Exception as e:
         logger.exception(f"failed to gracefully terminate LMS meta proc for {self.name}: {e}")
         logger.warning(f"forcefully killing LMS meta proc for {self.name}")
-        os.killpg(self.meta_proc.pid, signal.SIGKILL)
+        try:
+          os.killpg(os.getpgid(self.meta_proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+          pass
         self.meta_proc.communicate(timeout=3)
 
     self.proc = None


### PR DESCRIPTION
### What does this change intend to accomplish?

`LMS.disconnect()` falls back to `os.killpg(self.proc.pid, SIGKILL)`, but the spawned squeezelite/metadata processes were never made process-group leaders, so `proc.pid` is not a valid pgid — the killpg either fails or signals the parent's group. This starts both children with `preexec_fn=os.setpgrp` so each owns its own group, kills via `os.killpg(os.getpgid(pid))`, and tolerates `ProcessLookupError` when the process already exited (previously an exception escaped during stream teardown).

Running in production on our unit; stream stop/reassign no longer leaves orphaned squeezelite processes behind.

### Checklist

* [x] Have you tested your changes and ensured they work? (in production on a real AmpliPi)
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [ ] Does your submission pass linting & tests? (`python -m py_compile` clean; happy to fix anything CI flags)
