### PR TITLE
Disable USB autosuspend for the CM6206 USB audio device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Upgrade from Logitech Media Server 8.5.2 to Lyrion Music Server 9.0.3
   * Added in-place preamp recovery when I2C writes fail persistently
   * Fixed all loopback dmix devices sharing one ipc_key in asound.conf, which made loopback playback devices intermittently fail to open with EINVAL (#957)
+  * Disabled USB autosuspend for the CM6206 USB audio device
 * Web App
   * Add warning for older versions of the webapp running on newer backends
 

--- a/config/85-amplipi-usb-audio.rules
+++ b/config/85-amplipi-usb-audio.rules
@@ -1,1 +1,4 @@
 ACTION=="add", SUBSYSTEM=="sound", DEVPATH=="/devices/platform/soc/3f980000.usb/usb1/1-1/1-1.3/1-1.3\:1.0/sound/card?", ATTR{id}="cmedia8chint"
+
+# Disable USB autosuspend for CM6206 audio codec to prevent mid-stream suspend hang
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0d8c", ATTR{power/control}="on"


### PR DESCRIPTION
### What does this change intend to accomplish?

The CM6206 USB chip provides the digital outputs for sources 1–3; with kernel USB autosuspend active it can power down between uses and glitch on resume. This pins `power/control` to `on` from the same udev rule that already names the card.

### Checklist

* [x] Have you tested your changes and ensured they work? (in production on a real AmpliPi since 2026-06-08)
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
