### PR TITLE
Fix duplicate dmix ipc_key collisions in asound.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Update our spotify provider `go-librespot` to `0.7.3`
   * Upgrade from Logitech Media Server 8.5.2 to Lyrion Music Server 9.0.3
   * Added in-place preamp recovery when I2C writes fail persistently
+  * Fixed all loopback dmix devices sharing one ipc_key in asound.conf, which made loopback playback devices intermittently fail to open with EINVAL (#957)
 * Web App
   * Add warning for older versions of the webapp running on newer backends
 

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -71,6 +71,7 @@ pcm.dmixer {
         period_size 1024
         buffer_size 4096
         channels    8
+        rate        48000
     }
     bindings {
         0 0
@@ -249,7 +250,7 @@ pcm.lb0c {
 }
 pcm.lb1 {
     type dmix
-    ipc_key         1028
+    ipc_key         1029
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_1,0"
@@ -266,7 +267,7 @@ pcm.lb1c {
 
 pcm.lb2 {
     type dmix
-    ipc_key         1028
+    ipc_key         1030
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_2,0"
@@ -282,7 +283,7 @@ pcm.lb2c {
 }
 pcm.lb3 {
     type dmix
-    ipc_key         1028
+    ipc_key         1031
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_3,0"
@@ -298,7 +299,7 @@ pcm.lb3c {
 }
 pcm.lb4 {
     type dmix
-    ipc_key         1028
+    ipc_key         1032
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_4,0"
@@ -314,7 +315,7 @@ pcm.lb4c {
 }
 pcm.lb5 {
     type dmix
-    ipc_key         1028
+    ipc_key         1033
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_5,0"
@@ -332,7 +333,7 @@ pcm.lb5c {
 
 pcm.lb6 {
     type dmix
-    ipc_key         1028
+    ipc_key         1034
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback,1"
@@ -348,7 +349,7 @@ pcm.lb6c {
 }
 pcm.lb7 {
     type dmix
-    ipc_key         1028
+    ipc_key         1035
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_1,1"
@@ -365,7 +366,7 @@ pcm.lb7c {
 
 pcm.lb8 {
     type dmix
-    ipc_key         1028
+    ipc_key         1036
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_2,1"
@@ -381,7 +382,7 @@ pcm.lb8c {
 }
 pcm.lb9 {
     type dmix
-    ipc_key         1028
+    ipc_key         1037
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_3,1"
@@ -397,7 +398,7 @@ pcm.lb9c {
 }
 pcm.lb10 {
     type dmix
-    ipc_key         1028
+    ipc_key         1038
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_4,1"
@@ -413,7 +414,7 @@ pcm.lb10c {
 }
 pcm.lb11 {
     type dmix
-    ipc_key         1028
+    ipc_key         1039
     ipc_perm        0666
     slave {
         pcm         "hw:Loopback_5,1"


### PR DESCRIPTION
### What does this change intend to accomplish?

All twelve loopback dmix devices in `asound.conf` share `ipc_key 1028`. dmix instances with the same ipc_key collide on one shared-memory segment, so opening a loopback playback device intermittently fails with `EINVAL` / `snd_pcm_dmix_open: unable to open slave` depending on open order and which zones are active. The player on that source then crash-loops: on our production unit the LMS player flapped 189 times/day until we made the keys unique. The log signature is identical to #957 (`lb4c ... unable to open slave ... EINVAL`), so I believe this is that issue's root cause. The patch gives every loopback dmix a unique ipc_key and pins the 8ch dmixer slave rate to 48000 so its format can't drift from the loopbacks.

Running in production on a stock 0.4.10 unit since 2026-06-08 with zero loopback open failures since (previously several per day).

### Checklist

* [x] Have you tested your changes and ensured they work? (in production on a real AmpliPi since 2026-06-08)
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] If applicable, have you updated the CHANGELOG?
* [ ] Does your submission pass linting & tests? (config-only change; happy to fix anything CI flags)


NOTE: This was originally pr #1095, I just screwed up the git history and didn't have the rights to fix it in that PR due to not owning the branch origin. Thank you to stamateviorel for this work!