### PR TITLE
fix(web): preserve player metadata width

### DIFF
--- a/web/src/pages/Player/Player.jsx
+++ b/web/src/pages/Player/Player.jsx
@@ -98,7 +98,7 @@ const Player = () => {
                         </Chip>
                     </div>
                 </Grid>
-                <Grid item xs={2} sm={4} md={4} style={{maxWidth: "22rem"}}>
+                <Grid item xs={2} sm={4} md={4} className="player-metadata-container">
                     <Box
                         className="album-art-container"
                         sx={{

--- a/web/src/pages/Player/Player.scss
+++ b/web/src/pages/Player/Player.scss
@@ -42,19 +42,20 @@
   max-height: 22rem;
   object-fit: contain;
   border-radius: 2.5%;
-  @media (general.$is-portrait) {
-    max-width: 98vw;
-    max-height: 98vw;
-  }
 }
 
-@media (general.$is-portrait) {
+@media (general.$is-portrait) and (max-width: general.$medium-mobile) {
   .player-metadata-container {
     width: 98vw;
   }
 
   .album-art-container {
     min-height: 98vw;
+  }
+
+  .player-album-art {
+    max-width: 98vw;
+    max-height: 98vw;
   }
 }
 

--- a/web/src/pages/Player/Player.scss
+++ b/web/src/pages/Player/Player.scss
@@ -26,15 +26,35 @@
   padding-right: 2.5vw;
 }
 
+.player-metadata-container {
+  width: 22rem;
+  max-width: 98vw;
+}
+
+.album-art-container {
+  width: 100%;
+  min-height: 22rem;
+}
+
 .player-album-art {
   align-self: center;
+  max-width: 100%;
   max-height: 22rem;
+  object-fit: contain;
   border-radius: 2.5%;
   @media (general.$is-portrait) {
-    max-width: 85vw;
+    max-width: 98vw;
+    max-height: 98vw;
   }
-  @media (max-width: general.$small-mobile) {
-    max-width: 50vw;
+}
+
+@media (general.$is-portrait) {
+  .player-metadata-container {
+    width: 98vw;
+  }
+
+  .album-art-container {
+    min-height: 98vw;
   }
 }
 

--- a/web/src/pages/Player/Player.scss
+++ b/web/src/pages/Player/Player.scss
@@ -28,12 +28,6 @@
 
 .player-metadata-container {
   width: 22rem;
-  max-width: 98vw;
-}
-
-.album-art-container {
-  width: 100%;
-  min-height: 22rem;
 }
 
 .player-album-art {

--- a/web/src/pages/Player/Player.scss
+++ b/web/src/pages/Player/Player.scss
@@ -38,25 +38,12 @@
 
 .player-album-art {
   align-self: center;
-  max-width: 100%;
-  max-height: 22rem;
+  min-width: 22rem;
+  min-height: 22rem;
+  max-width: 352px;
+  max-height: 352px;
   object-fit: contain;
   border-radius: 2.5%;
-}
-
-@media (general.$is-portrait) and (max-width: general.$medium-mobile) {
-  .player-metadata-container {
-    width: 98vw;
-  }
-
-  .album-art-container {
-    min-height: 98vw;
-  }
-
-  .player-album-art {
-    max-width: 98vw;
-    max-height: 98vw;
-  }
 }
 
 // Solo vs Grouped media controls are different because solo volumes have titles, making them tall enough to need further adjustment


### PR DESCRIPTION
## Summary
- Give the player metadata column a stable width independent of album art load state
- Reserve a square album-art area so missing or broken art does not scrunch song metadata
- Keep album art contained within the reserved desktop/mobile footprint

Fixes #1103

## Validation
- `cd web && npm ci`
- `cd web && npm run build`
- `git diff --check`

Note: `npm ci` completed but reported existing dependency audit findings (1 low, 9 moderate, 11 high). No dependency files were changed.