### PR TITLE
fix(web): preserve player metadata width

### DIFF
--- a/web/src/pages/Player/Player.jsx
+++ b/web/src/pages/Player/Player.jsx
@@ -98,7 +98,7 @@ const Player = () => {
                         </Chip>
                     </div>
                 </Grid>
-                <Grid item xs={2} sm={4} md={4} style={{maxWidth: "22rem"}}>
+                <Grid item xs={2} sm={4} md={4} className="player-metadata-container">
                     <Box
                         className="album-art-container"
                         sx={{

--- a/web/src/pages/Player/Player.scss
+++ b/web/src/pages/Player/Player.scss
@@ -26,15 +26,23 @@
   padding-right: 2.5vw;
 }
 
+.player-metadata-container {
+  width: 22rem;
+}
+
 .player-album-art {
   align-self: center;
-  max-height: 22rem;
+  min-width: 22rem;
+  min-height: 22rem;
+  max-width: 352px;
+  max-height: 352px;
+  object-fit: contain;
   border-radius: 2.5%;
-  @media (general.$is-portrait) {
-    max-width: 85vw;
-  }
-  @media (max-width: general.$small-mobile) {
-    max-width: 50vw;
+  @media (max-width: general.$medium-mobile) {
+    min-width: 98vw;
+    min-height: 98vw;
+    max-width: 98vw;
+    max-height: 98vw;
   }
 }
 


### PR DESCRIPTION
## What does this change intend to accomplish?

Fixes #1103.

When album art is missing or fails to load, the image has no intrinsic size and the player metadata column collapses. This change reserves a square album-art area so song, album, and artist metadata retain a stable width:

- desktop: 22rem minimum and 352px maximum
- narrow screens: 98vw minimum and maximum
- loaded artwork remains contained without distortion

The metadata Grid now uses a class instead of an inline max-width so the responsive rules live in the stylesheet.

## Validation

- npm ci
- npm run build
- git diff --check

The build passed. npm ci reported the repository's existing dependency audit findings (1 low, 9 moderate, 11 high). Cross-browser manual testing was not available in this environment.